### PR TITLE
Сохранить совместимость авторизации, XSRF и сессии Интеграма

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T06:29:48.776Z for PR creation at branch issue-12-dac13744254d for issue https://github.com/ideav/vue-gram/issues/12

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T06:29:48.776Z for PR creation at branch issue-12-dac13744254d for issue https://github.com/ideav/vue-gram/issues/12

--- a/src/composables/useIntegramSession.js
+++ b/src/composables/useIntegramSession.js
@@ -13,8 +13,8 @@ const currentDatabase = ref(null);
 const userInfo = ref(null);
 
 export function useIntegramSession() {
-  function initializeSession() {
-    const restored = integramApiClient.tryRestoreSession();
+  function initializeSession(databaseHint = null) {
+    const restored = integramApiClient.tryRestoreSession(databaseHint);
     if (restored) {
       isAuthenticated.value = integramApiClient.isAuthenticated();
       currentDatabase.value = integramApiClient.getDatabase();
@@ -24,6 +24,7 @@ export function useIntegramSession() {
 
   async function login(serverURL, database, username, password) {
     try {
+      if (serverURL) integramApiClient.setServer(serverURL);
       await integramApiClient.authenticate(database, username, password);
       isAuthenticated.value = true;
       currentDatabase.value = database;
@@ -56,6 +57,7 @@ export function useIntegramSession() {
   return {
     isAuthenticated: computed(() => isAuthenticated.value),
     currentDatabase: computed(() => currentDatabase.value),
+    database: computed(() => currentDatabase.value),
     userInfo: computed(() => userInfo.value),
     login,
     logout,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import integramApiClient from '../services/integramApiClient'
 
 const routes = [
   {
@@ -90,18 +91,15 @@ const router = createRouter({
 })
 
 // Auth guard
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to) => {
   if (to.matched.some(record => record.meta.requiresAuth)) {
-    const token = localStorage.getItem('token')
-    const session = localStorage.getItem('integram_session')
-    if (!token && !session) {
-      next({ path: '/login', query: { redirect: to.fullPath } })
-    } else {
-      next()
+    const database = typeof to.params.database === 'string' ? to.params.database : null
+    const restored = await integramApiClient.restoreSession(database)
+    if (!restored) {
+      return { path: '/login', query: { redirect: to.fullPath } }
     }
-  } else {
-    next()
   }
+  return true
 })
 
 export default router

--- a/src/services/__tests__/integramApiClient.spec.js
+++ b/src/services/__tests__/integramApiClient.spec.js
@@ -15,6 +15,8 @@ describe('IntegramApiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    document.cookie = 'idb_my=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/'
+    document.cookie = 'my=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/'
 
     client = new IntegramApiClient()
     client.setServer('https://app.integram.io')
@@ -54,5 +56,91 @@ describe('IntegramApiClient', () => {
 
     expect(url).toBe('https://app.integram.io/api/my/_m_del/9001')
     expect(body.get('_xsrf')).toBe('xsrf-token')
+  })
+
+  it('restores legacy localStorage sessions for the saved database', () => {
+    localStorage.setItem('token', 'legacy-token')
+    localStorage.setItem('_xsrf', 'legacy-xsrf')
+    localStorage.setItem('user', 'alice')
+    localStorage.setItem('id', '42')
+    localStorage.setItem('db', 'a2025')
+
+    const restoredClient = new IntegramApiClient()
+
+    expect(restoredClient.isAuthenticated()).toBe(true)
+    expect(restoredClient.getDatabase()).toBe('a2025')
+    expect(restoredClient.getAuthInfo()).toMatchObject({
+      token: 'legacy-token',
+      xsrf: 'legacy-xsrf',
+      userId: '42',
+      userName: 'alice',
+      database: 'a2025'
+    })
+  })
+
+  it('refreshes an existing session through the legacy xsrf endpoint with same-origin credentials', async () => {
+    client.setServer(window.location.origin)
+    axios.get.mockResolvedValue({
+      data: {
+        _xsrf: 'fresh-xsrf',
+        token: 'fresh-token',
+        id: '42',
+        user: 'alice',
+        role: 'admin'
+      }
+    })
+
+    await expect(client.validateSession()).resolves.toBe(true)
+
+    const [url, config] = axios.get.mock.calls[0]
+    expect(url).toBe(`${window.location.origin}/my/xsrf`)
+    expect(config.params).toEqual({ JSON: '' })
+    expect(config.withCredentials).toBe(true)
+    expect(client.getAuthInfo()).toMatchObject({
+      token: 'fresh-token',
+      xsrf: 'fresh-xsrf',
+      userId: '42',
+      userName: 'alice',
+      userRole: 'admin'
+    })
+  })
+
+  it('surfaces backend auth errors instead of replacing them with a generic message', async () => {
+    axios.post.mockRejectedValue({
+      response: {
+        status: 401,
+        data: {
+          error: 'Неверный логин или пароль alice @ my',
+          hint: 'Логин и пароль следует отправлять POST-параметрами.'
+        }
+      }
+    })
+
+    await expect(client.authenticate('my', 'alice', 'bad-password'))
+      .rejects.toThrow('Неверный логин или пароль alice @ my')
+  })
+
+  it('clears Vue and legacy auth storage on logout', () => {
+    localStorage.setItem('integram_session', '{"token":"auth-token"}')
+    localStorage.setItem('token', 'auth-token')
+    localStorage.setItem('_xsrf', 'xsrf-token')
+    localStorage.setItem('user', 'alice')
+    localStorage.setItem('id', '42')
+    localStorage.setItem('db', 'my')
+    localStorage.setItem('session_timestamp', '1')
+    document.cookie = 'idb_my=auth-token; path=/'
+    document.cookie = 'my=auth-token; path=/'
+
+    client.logout()
+
+    expect(localStorage.getItem('integram_session')).toBeNull()
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('_xsrf')).toBeNull()
+    expect(localStorage.getItem('user')).toBeNull()
+    expect(localStorage.getItem('id')).toBeNull()
+    expect(localStorage.getItem('db')).toBeNull()
+    expect(localStorage.getItem('session_timestamp')).toBeNull()
+    expect(document.cookie).not.toContain('idb_my=')
+    expect(document.cookie).not.toContain('my=')
   })
 })

--- a/src/services/integramApiClient.js
+++ b/src/services/integramApiClient.js
@@ -11,6 +11,56 @@
 
 import axios from 'axios'
 
+const LEGACY_AUTH_STORAGE_KEYS = [
+  'token',
+  '_xsrf',
+  'user',
+  'id',
+  'db',
+  'session_timestamp',
+  'my_token',
+  'my_xsrf',
+  'my_user',
+  'my_id'
+]
+
+function firstPayload(data) {
+  if (Array.isArray(data)) return data[0] || {}
+  return data || {}
+}
+
+function getApiMessage(data) {
+  const payload = firstPayload(data)
+  return payload.error || payload.message || payload.msg || payload.warning || payload.hint || ''
+}
+
+function getCookie(name) {
+  if (typeof document === 'undefined') return null
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = document.cookie.match(new RegExp(`(?:^|; )${escaped}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+function setCookie(name, value, maxAge = 2592000) {
+  if (typeof document === 'undefined' || !value) return
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}`
+}
+
+function deleteCookie(name) {
+  if (typeof document === 'undefined') return
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`
+}
+
+function getIdbCookieDatabases() {
+  if (typeof document === 'undefined') return []
+  return document.cookie
+    .split(';')
+    .map((cookie) => cookie.trim().split('=')[0])
+    .filter((name) => name.startsWith('idb_'))
+    .map((name) => name.slice(4))
+    .filter(Boolean)
+}
+
 export function formatRequisiteValue(value) {
   if (value === null || value === undefined || value === '') return value
 
@@ -88,14 +138,33 @@ export class IntegramApiClient {
     return this.baseURL
   }
 
-  setCredentials(database, token, xsrf = null, authDatabase = null) {
+  setCredentials(database, token, xsrf = null, authDatabase = null, session = {}) {
     this.database = database
     this.token = token
     this.xsrfToken = xsrf || token
+    this.currentDatabase = database
     this.authDatabase = authDatabase || database
+    this.userId = session.userId ?? this.userId
+    this.userName = session.userName ?? this.userName
+    this.userRole = session.userRole ?? this.userRole
+
+    if (database && token) {
+      const existing = this.databases[database] || {}
+      this.databases[database] = {
+        ...existing,
+        token,
+        xsrfToken: this.xsrfToken,
+        userId: this.userId,
+        userName: this.userName,
+        userRole: this.userRole,
+        ownedDatabases: existing.ownedDatabases || []
+      }
+    }
   }
 
   saveSession() {
+    this.saveLegacyAuthState()
+
     if (Object.keys(this.databases).length > 0) {
       const sessionData = {
         version: 2,
@@ -124,6 +193,50 @@ export class IntegramApiClient {
     }
   }
 
+  saveLegacyAuthState() {
+    if (!this.token || !this.xsrfToken || !this.database) return
+
+    localStorage.setItem('token', this.token)
+    localStorage.setItem('_xsrf', this.xsrfToken)
+    localStorage.setItem('db', this.database)
+    localStorage.setItem('session_timestamp', Date.now().toString())
+    if (this.userName) localStorage.setItem('user', this.userName)
+    if (this.userId) localStorage.setItem('id', this.userId)
+
+    if (this.shouldWriteSameOriginCookies()) {
+      setCookie(`idb_${this.database}`, this.token)
+      setCookie(this.database, this.token)
+    }
+  }
+
+  applySession(database, session = {}, authDatabase = null) {
+    const token = session.token || session.authToken || this.token
+    const xsrfToken = session.xsrfToken || session._xsrf || session.xsrf || this.xsrfToken
+    if (!database || !token) return false
+
+    this.database = database
+    this.currentDatabase = database
+    this.token = token
+    this.xsrfToken = xsrfToken || null
+    this.userId = session.userId || session.id || this.userId
+    this.userName = session.userName || session.user || this.userName
+    this.userRole = session.userRole || session.role || this.userRole
+    this.authDatabase = authDatabase || session.authDatabase || database
+
+    const existing = this.databases[database] || {}
+    this.databases[database] = {
+      ...existing,
+      token: this.token,
+      xsrfToken: this.xsrfToken,
+      userId: this.userId,
+      userName: this.userName,
+      userRole: this.userRole,
+      ownedDatabases: session.ownedDatabases || existing.ownedDatabases || []
+    }
+
+    return true
+  }
+
   loadSession() {
     try {
       const stored = localStorage.getItem('integram_session')
@@ -136,14 +249,7 @@ export class IntegramApiClient {
           this.currentDatabase = sessionData.currentDatabase
 
           if (this.currentDatabase && this.databases[this.currentDatabase]) {
-            const currentDBSession = this.databases[this.currentDatabase]
-            this.database = this.currentDatabase
-            this.token = currentDBSession.token
-            this.xsrfToken = currentDBSession.xsrfToken
-            this.userId = currentDBSession.userId
-            this.userName = currentDBSession.userName
-            this.userRole = currentDBSession.userRole
-            this.authDatabase = this.currentDatabase
+            this.applySession(this.currentDatabase, this.databases[this.currentDatabase])
           }
 
           localStorage.setItem('integram_server', this.baseURL)
@@ -151,26 +257,8 @@ export class IntegramApiClient {
         }
 
         // Legacy format
-        this.database = sessionData.database
-        this.token = sessionData.token
-        this.xsrfToken = sessionData.xsrfToken
-        this.userId = sessionData.userId
-        this.userName = sessionData.userName
-        this.userRole = sessionData.userRole
-        this.authDatabase = sessionData.authDatabase || sessionData.database
-
-        if (this.database && this.token) {
-          this.databases[this.database] = {
-            token: this.token,
-            xsrfToken: this.xsrfToken,
-            userId: this.userId,
-            userName: this.userName,
-            userRole: this.userRole,
-            ownedDatabases: []
-          }
-          this.currentDatabase = this.database
-          this.saveSession()
-        }
+        this.applySession(sessionData.database, sessionData, sessionData.authDatabase || sessionData.database)
+        if (this.database && this.token) this.saveSession()
 
         if (sessionData.authServer) {
           this.baseURL = sessionData.authServer
@@ -179,50 +267,71 @@ export class IntegramApiClient {
         return
       }
 
-      this.loadSessionFromMyToken()
+      this.loadSessionFromLegacySources()
     } catch (error) {
       console.error('Failed to load session from localStorage:', error)
       localStorage.removeItem('integram_session')
     }
   }
 
-  loadSessionFromMyToken() {
+  loadSessionFromLegacySources(databaseHint = null) {
     try {
+      if (this.loadSessionFromWindowGlobals(databaseHint)) return true
+
       const myToken = localStorage.getItem('my_token')
       const myXsrf = localStorage.getItem('my_xsrf')
       const myUser = localStorage.getItem('my_user')
       const myUserId = localStorage.getItem('my_id')
 
       if (myToken && myXsrf) {
-        this.database = 'my'
-        this.token = myToken
-        this.xsrfToken = myXsrf
-        this.userId = myUserId
-        this.userName = myUser
-        this.authDatabase = 'my'
-        return true
+        return this.applySession('my', {
+          token: myToken,
+          xsrfToken: myXsrf,
+          userId: myUserId,
+          userName: myUser
+        }, 'my')
       }
 
       const legacyToken = localStorage.getItem('token')
       const legacyXsrf = localStorage.getItem('_xsrf')
       const legacyUser = localStorage.getItem('user')
       const legacyUserId = localStorage.getItem('id')
-      const currentDb = localStorage.getItem('db')
+      const currentDb = databaseHint || localStorage.getItem('db') || localStorage.getItem('last_db') || 'my'
 
-      if (legacyToken && legacyXsrf && currentDb === 'my') {
-        this.database = 'my'
-        this.token = legacyToken
-        this.xsrfToken = legacyXsrf
-        this.userId = legacyUserId
-        this.userName = legacyUser
-        this.authDatabase = 'my'
-        return true
+      if (legacyToken && legacyXsrf && currentDb) {
+        return this.applySession(currentDb, {
+          token: legacyToken,
+          xsrfToken: legacyXsrf,
+          userId: legacyUserId,
+          userName: legacyUser
+        }, currentDb)
       }
 
       return false
     } catch (error) {
       return false
     }
+  }
+
+  loadSessionFromMyToken(databaseHint = null) {
+    return this.loadSessionFromLegacySources(databaseHint)
+  }
+
+  loadSessionFromWindowGlobals(databaseHint = null) {
+    if (typeof window === 'undefined') return false
+    const database = databaseHint || window.db
+    const token = window.token
+    const xsrfToken = window.xsrf
+
+    if (!database || !token || !xsrfToken) return false
+
+    return this.applySession(database, {
+      token,
+      xsrfToken,
+      userId: window.uid || window.id,
+      userName: window.user,
+      userRole: window.role
+    }, database)
   }
 
   setDatabase(database) {
@@ -238,14 +347,28 @@ export class IntegramApiClient {
   }
 
   async validateSession() {
-    if (!this.token || !this.xsrfToken) return false
+    if (!this.token || !this.database) return false
     try {
-      const response = await this.get('xsrf')
-      if (response.token) this.token = response.token
-      if (response._xsrf) this.xsrfToken = response._xsrf
-      if (response.id) this.userId = response.id
-      if (response.user) this.userName = response.user
-      if (response.role) this.userRole = response.role
+      const url = this.buildURL('xsrf')
+      const response = await axios.get(url, {
+        params: { JSON: '' },
+        headers: this.getAuthHeaders(this.database),
+        timeout: 30000,
+        withCredentials: this.shouldUseCredentials(url)
+      })
+      const data = firstPayload(response.data)
+
+      if (!data._xsrf && !data.xsrf) {
+        throw new Error(getApiMessage(data) || 'Сервер не вернул XSRF токен')
+      }
+
+      this.applySession(this.database, {
+        token: data.token || this.token,
+        xsrfToken: data._xsrf || data.xsrf,
+        userId: data.id,
+        userName: data.user,
+        userRole: data.role
+      }, this.authDatabase || this.database)
       this.saveSession()
       return true
     } catch (error) {
@@ -253,8 +376,14 @@ export class IntegramApiClient {
     }
   }
 
-  tryRestoreSession() {
-    if (this.isAuthenticated()) return true
+  tryRestoreSession(databaseHint = null) {
+    if (databaseHint && this.databases[databaseHint]) {
+      return this.applySession(databaseHint, this.databases[databaseHint])
+    }
+    if (this.isAuthenticated() && (!databaseHint || this.database === databaseHint || this.authDatabase === 'my')) {
+      if (databaseHint && this.database !== databaseHint && this.authDatabase === 'my') this.database = databaseHint
+      return true
+    }
 
     const stored = localStorage.getItem('integram_session')
     if (stored) {
@@ -263,29 +392,16 @@ export class IntegramApiClient {
 
         if (sessionData.version === 2 && sessionData.databases) {
           this.databases = sessionData.databases
-          this.currentDatabase = sessionData.currentDatabase
+          this.currentDatabase = databaseHint || sessionData.currentDatabase
           if (this.currentDatabase && this.databases[this.currentDatabase]) {
-            const s = this.databases[this.currentDatabase]
-            this.database = this.currentDatabase
-            this.token = s.token
-            this.xsrfToken = s.xsrfToken
-            this.userId = s.userId
-            this.userName = s.userName
-            this.userRole = s.userRole
-            this.authDatabase = this.currentDatabase
+            this.applySession(this.currentDatabase, this.databases[this.currentDatabase])
           }
           if (sessionData.server) this.baseURL = sessionData.server
-          return true
+          return this.isAuthenticated()
         }
 
         if (sessionData.token && sessionData.xsrfToken) {
-          this.database = sessionData.database
-          this.token = sessionData.token
-          this.xsrfToken = sessionData.xsrfToken
-          this.userId = sessionData.userId
-          this.userName = sessionData.userName
-          this.userRole = sessionData.userRole
-          this.authDatabase = sessionData.authDatabase || sessionData.database
+          this.applySession(databaseHint || sessionData.database, sessionData, sessionData.authDatabase || sessionData.database)
           if (sessionData.authServer) this.baseURL = sessionData.authServer
           return true
         }
@@ -294,7 +410,28 @@ export class IntegramApiClient {
       }
     }
 
-    return this.loadSessionFromMyToken()
+    return this.loadSessionFromLegacySources(databaseHint)
+  }
+
+  async restoreSession(databaseHint = null, options = {}) {
+    const { validate = true } = options
+    this.tryRestoreSession(databaseHint)
+
+    const database = databaseHint || this.database || localStorage.getItem('db') || localStorage.getItem('last_db') || 'my'
+    if (!this.token && database) {
+      const cookieToken = getCookie(`idb_${database}`)
+      if (cookieToken) {
+        this.applySession(database, { token: cookieToken, xsrfToken: null }, database)
+      }
+    }
+
+    if (!this.token) return false
+    if (!this.database && database) this.database = database
+    if (!validate) return this.isAuthenticated()
+
+    const restored = await this.validateSession()
+    if (!restored) this.clearDatabaseSession(database)
+    return restored
   }
 
   getAuthInfo() {
@@ -315,9 +452,12 @@ export class IntegramApiClient {
 
     let cleanBaseURL = this.baseURL.replace(/\/$/, '')
     const isIPAddress = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(cleanBaseURL)
-    const isDronedoc = cleanBaseURL.includes('dronedoc.ru') || cleanBaseURL.includes('sakhwings.ru') || isIPAddress
+    const isLegacyHost = cleanBaseURL.includes('dronedoc.ru') ||
+      cleanBaseURL.includes('sakhwings.ru') ||
+      isIPAddress ||
+      this.isSameOriginBase(cleanBaseURL)
 
-    if (isDronedoc) {
+    if (isLegacyHost) {
       const dbPathRegex = new RegExp(`/${this.database}$`)
       if (dbPathRegex.test(cleanBaseURL)) return `${cleanBaseURL}/${endpoint}`
       if (endpoint.startsWith(`${this.database}/`)) return `${cleanBaseURL}/${endpoint}`
@@ -333,21 +473,25 @@ export class IntegramApiClient {
       const url = this.buildURL('auth')
 
       const formData = new URLSearchParams()
+      formData.append('db', database)
       formData.append('login', login)
       formData.append('pwd', password)
 
       const response = await axios.post(url, formData, {
-        params: { JSON_KV: '' },
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        params: { JSON: '' },
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        withCredentials: this.shouldUseCredentials(url)
       })
 
-      if (response.data.failed) {
-        throw new Error('Неверный логин или пароль')
+      const data = firstPayload(response.data)
+
+      if (data.error || data.failed) {
+        throw new Error(getApiMessage(data) || 'Неверный логин или пароль')
       }
 
-      const receivedToken = response.data.token
+      const receivedToken = data.token
       if (!receivedToken) {
-        throw new Error('Сервер не вернул токен авторизации')
+        throw new Error(getApiMessage(data) || 'Сервер не вернул токен авторизации')
       }
 
       if (receivedToken === password) {
@@ -357,19 +501,19 @@ export class IntegramApiClient {
       // Save to multi-database structure
       this.databases[database] = {
         token: receivedToken,
-        xsrfToken: response.data._xsrf,
-        userId: response.data.id,
-        userName: login,
-        userRole: response.data.role || 'user',
+        xsrfToken: data._xsrf || data.xsrf,
+        userId: data.id,
+        userName: data.user || login,
+        userRole: data.role || 'user',
         ownedDatabases: []
       }
 
       this.currentDatabase = database
       this.token = receivedToken
-      this.xsrfToken = response.data._xsrf
-      this.userId = response.data.id
-      this.userName = login
-      this.userRole = response.data.role || 'user'
+      this.xsrfToken = data._xsrf || data.xsrf
+      this.userId = data.id
+      this.userName = data.user || login
+      this.userRole = data.role || 'user'
       this.database = database
       this.authDatabase = database
 
@@ -389,14 +533,14 @@ export class IntegramApiClient {
         success: true,
         database,
         token: receivedToken,
-        xsrf: response.data._xsrf,
+        xsrf: data._xsrf || data.xsrf,
         userId: this.userId,
         userName: this.userName,
         userRole: this.userRole,
         ownedDatabases: this.databases[database].ownedDatabases
       }
     } catch (error) {
-      throw new Error(error.response?.data?.message || error.message || 'Ошибка авторизации')
+      throw new Error(getApiMessage(error.response?.data) || error.message || 'Ошибка авторизации')
     }
   }
 
@@ -483,17 +627,52 @@ export class IntegramApiClient {
   }
 
   clearSession() {
+    for (const key of LEGACY_AUTH_STORAGE_KEYS) localStorage.removeItem(key)
     localStorage.removeItem('integram_session')
   }
 
-  logout() {
+  clearDatabaseSession(database = this.database) {
+    if (database) {
+      delete this.databases[database]
+      deleteCookie(`idb_${database}`)
+      deleteCookie(database)
+    }
+    if (!database || this.database === database || this.currentDatabase === database) {
+      this.token = null
+      this.xsrfToken = null
+      this.userId = null
+      this.userName = null
+      this.userRole = null
+      this.database = null
+      this.currentDatabase = null
+      this.authDatabase = null
+    }
+    this.clearSession()
+  }
+
+  logout(database = this.database, options = {}) {
+    const { all = true } = options
+    const knownDatabases = new Set([
+      database,
+      this.database,
+      this.currentDatabase,
+      localStorage.getItem('db'),
+      ...Object.keys(this.databases),
+      ...getIdbCookieDatabases()
+    ].filter(Boolean))
+
+    for (const dbName of knownDatabases) {
+      deleteCookie(`idb_${dbName}`)
+      deleteCookie(dbName)
+    }
+
     this.token = null
     this.xsrfToken = null
     this.userId = null
     this.userName = null
     this.userRole = null
     this.database = null
-    this.databases = {}
+    this.databases = all ? {} : this.databases
     this.currentDatabase = null
     this.clearSession()
   }
@@ -510,7 +689,8 @@ export class IntegramApiClient {
       const response = await axios.get(url, {
         params: { JSON_KV: '', ...params },
         headers,
-        timeout: 30000
+        timeout: 30000,
+        withCredentials: this.shouldUseCredentials(url)
       })
 
       return response.data
@@ -545,6 +725,7 @@ export class IntegramApiClient {
         params: { JSON_KV: '' },
         headers,
         timeout: 30000,
+        withCredentials: this.shouldUseCredentials(url),
         ...options
       })
 
@@ -563,23 +744,42 @@ export class IntegramApiClient {
     }
     if (error.response) {
       const { status, data } = error.response
+      const message = getApiMessage(data)
       if (status === 401) {
-        if (this.tryRestoreSession()) {
-          const retryError = new Error('SESSION_RESTORED_RETRY')
-          retryError.canRetry = true
-          return retryError
-        }
-        return new Error('Сессия истекла. Обновите страницу или войдите заново.')
+        this.clearDatabaseSession(this.database)
+        return new Error(message || 'Сессия истекла. Обновите страницу или войдите заново.')
       }
-      if (status === 403) return new Error('Доступ запрещен.')
+      if (status === 403) return new Error(message || 'Доступ запрещен.')
       if (status === 404) return new Error('Ресурс не найден.')
-      if (status === 500) return new Error('Ошибка сервера: ' + (data.message || data.error || 'Internal server error'))
-      return new Error(data.message || data.error || `HTTP ${status}`)
+      if (status === 500) return new Error('Ошибка сервера: ' + (message || 'Internal server error'))
+      return new Error(message || `HTTP ${status}`)
     }
     if (error.request) {
       return new Error('Нет ответа от сервера. Проверьте подключение к сети.')
     }
     return error
+  }
+
+  isSameOriginBase(baseURL) {
+    if (typeof window === 'undefined') return false
+    try {
+      return new URL(baseURL, window.location.origin).origin === window.location.origin
+    } catch (error) {
+      return false
+    }
+  }
+
+  shouldUseCredentials(url) {
+    if (typeof window === 'undefined') return false
+    try {
+      return new URL(url, window.location.origin).origin === window.location.origin
+    } catch (error) {
+      return false
+    }
+  }
+
+  shouldWriteSameOriginCookies() {
+    return this.isSameOriginBase(this.baseURL)
   }
 
   // DDL Operations

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -50,6 +50,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   async function authenticateToDatabase(login, password, apiBase, database) {
     const formData = new URLSearchParams()
+    formData.append('db', database)
     formData.append('login', login)
     formData.append('pwd', password)
 
@@ -79,9 +80,9 @@ export const useAuthStore = defineStore('auth', () => {
 
     return {
       token: data.token,
-      _xsrf: data._xsrf,
+      _xsrf: data._xsrf || data.xsrf,
       id: data.id,
-      user: login
+      user: data.user || login
     }
   }
 

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -8,6 +8,24 @@ import { ref, computed } from 'vue'
 import axios from 'axios'
 import { setItemSafe, removeItemSafe } from '@/utils/localStorage'
 
+function firstPayload(data) {
+  if (Array.isArray(data)) return data[0] || {}
+  return data || {}
+}
+
+function getAuthMessage(data) {
+  const payload = firstPayload(data)
+  return payload.error || payload.message || payload.msg || payload.warning || payload.hint || 'Authentication failed'
+}
+
+function shouldUseCredentials(baseURL) {
+  try {
+    return new URL(baseURL, window.location.origin).origin === window.location.origin
+  } catch (error) {
+    return false
+  }
+}
+
 export const useAuthStore = defineStore('auth', () => {
   const primaryToken = ref(null)
   const primaryUser = ref(null)
@@ -45,18 +63,18 @@ export const useAuthStore = defineStore('auth', () => {
     const client = axios.create({
       baseURL,
       timeout: 30000,
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      withCredentials: shouldUseCredentials(baseURL)
     })
 
     const response = await client.post('/auth', formData, {
-      params: { JSON_KV: true }
+      params: { JSON: '' }
     })
 
-    let data = response.data
-    if (Array.isArray(data) && data.length > 0) data = data[0]
+    const data = firstPayload(response.data)
 
     if (!data.token) {
-      throw new Error(data.error || data.warning || 'Authentication failed')
+      throw new Error(getAuthMessage(data))
     }
 
     return {

--- a/src/views/integram/IntegramLogin.vue
+++ b/src/views/integram/IntegramLogin.vue
@@ -164,7 +164,7 @@
         </div>
 
         <Message v-if="error" severity="error" :closable="false" class="mb-3">
-          {{ t('wrongCredentials') }}
+          {{ error }}
         </Message>
 
         <Button
@@ -577,8 +577,7 @@ async function enterDatabase(dbName) {
 // Logout from all databases
 async function handleLogout() {
   try {
-    // Clear all authenticated databases
-    integramApiClient.databases = {}
+    integramApiClient.logout()
 
     toast.add({
       severity: 'info',
@@ -594,6 +593,7 @@ async function handleLogout() {
       login: '',
       password: ''
     }
+    error.value = null
 
     // Stay on login page
   } catch (error) {

--- a/src/views/integram/IntegramMain.vue
+++ b/src/views/integram/IntegramMain.vue
@@ -409,8 +409,8 @@ async function changePassword() {
       if (response.token) {
         integramApiClient.token = response.token
       }
-      if (response.xsrf) {
-        integramApiClient.xsrfToken = response.xsrf
+      if (response._xsrf || response.xsrf) {
+        integramApiClient.xsrfToken = response._xsrf || response.xsrf
       }
 
       // Save updated session
@@ -489,8 +489,7 @@ async function handleDatabaseChange(event) {
 }
 
 function logout() {
-  integramApiClient.logout()
-  document.cookie = `${database.value}=;Path=/`
+  integramApiClient.logout(database.value)
   router.push('/login')
 }
 
@@ -509,63 +508,20 @@ watch(() => route.params.database, async (newDb) => {
 // Lifecycle
 onMounted(async () => {
   // Issue #5100: Try to restore session before checking auth
-  integramApiClient.tryRestoreSession()
+  await integramApiClient.restoreSession(database.value, { validate: false })
 
   // Issue #4168: Check Integram authentication (independent from main site auth)
   const authInfo = integramApiClient.getAuthInfo()
   if (!authInfo.token || !authInfo.xsrf) {
-    // Issue #34: Auto-authenticate with default credentials (without requiring manual login)
-    const serverURL = import.meta.env.VITE_INTEGRAM_URL || `${window.location.protocol}//${window.location.hostname}`
-    const defaultDatabase = database.value || 'my'
-    const defaultUsername = 'd'
-    const defaultPassword = 'd'
-
-    try {
-      console.log('[IntegramMain] Auto-authenticating with database:', defaultDatabase)
-      await integramApiClient.authenticate(serverURL, defaultDatabase, defaultUsername, defaultPassword)
-
-      // Get user info after authentication
-      const response = await integramApiClient.get(`/${defaultDatabase}/auth?JSON`)
-      if (response.data) {
-        const dbSession = integramApiClient.databases[defaultDatabase]
-        if (dbSession) {
-          dbSession.userName = response.data.login || defaultUsername
-          dbSession.userRole = response.data.role || 'user'
-          dbSession.authInfo = {
-            userName: response.data.login || defaultUsername,
-            userRole: response.data.role || 'user',
-            token: dbSession.token,
-            xsrf: dbSession.xsrfToken
-          }
-
-          // Get owned databases list
-          if (response.data.bases && Array.isArray(response.data.bases)) {
-            dbSession.ownedDatabases = response.data.bases
-          }
-        }
-      }
-
-      // Save session to localStorage
-      integramApiClient.saveSession()
-
-      console.log('[IntegramMain] Auto-authentication successful')
-    } catch (error) {
-      console.error('[IntegramMain] Auto-authentication failed:', error)
-      toast.add({
-        severity: 'error',
-        summary: 'Ошибка автоматической авторизации',
-        detail: error.message || 'Не удалось войти в систему',
-        life: 5000
-      })
-      return
-    }
+    router.replace({ path: '/login', query: { redirect: route.fullPath } })
+    return
   }
 
   // Issue #5100: Validate session to refresh tokens and prevent quick expiration
-  try {
-    await integramApiClient.validateSession()
-  } catch (e) {
-    console.warn('Session validation skipped:', e.message)
+  const validSession = await integramApiClient.validateSession()
+  if (!validSession) {
+    router.replace({ path: '/login', query: { redirect: route.fullPath } })
+    return
   }
 
   // Load locale from localStorage - default to ru if not set


### PR DESCRIPTION
Fixes #12

## Summary
- Restore Integram sessions from the Vue session store, legacy localStorage keys, window globals, and same-origin `idb_<db>` cookies.
- Validate restored sessions through the legacy `/{db}/xsrf?JSON` endpoint with same-origin credentials, refreshing `token` / `_xsrf` / user metadata from the backend response.
- Preserve backend auth error messages and normalize `error`, `message`, `msg`, `warning`, and `hint` payloads.
- Keep login/logout compatible with the legacy contract by posting `db`, `login`, and `pwd`, clearing Vue plus legacy storage/cookies, and redirecting stale sessions to `/login?redirect=...`.
- Remove the default `d` / `d` auto-login fallback from protected Integram routes.

## Verification
- `npm test`
- `npm run build`
- `npm run test:e2e` attempted, but the external Integram host could not be resolved in this environment: `curl: (6) Could not resolve host: dronedoc.ru`. The browser login flow showed the corresponding Network Error before route assertions could run.
