### PR TITLE
Перенести карточку объекта и список объектов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T06:35:02.350Z for PR creation at branch issue-17-fbd64276726c for issue https://github.com/ideav/vue-gram/issues/17

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T06:35:02.350Z for PR creation at branch issue-17-fbd64276726c for issue https://github.com/ideav/vue-gram/issues/17

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,5 +1,80 @@
 import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
 
+const objectListResponse = {
+  type: { id: '110', val: 'Contracts', up: '0' },
+  object: [
+    { id: '285', val: 'Contract A', ord: 1, up: '1' },
+  ],
+  list: [
+    {
+      id: '285',
+      val: 'Contract A',
+      up: '1',
+      320: 'ACME',
+      ref_320: '200:42',
+      410: 'Urgent, External',
+      ref_410: '210:7,8',
+      411: '3',
+    },
+  ],
+  req_order: ['320', '410', '411'],
+  req_type: {
+    320: 'Client',
+    410: 'Tags',
+    411: 'Tasks',
+  },
+  req_base: {
+    320: 'SHORT',
+    410: 'SHORT',
+    411: 'ARRAY',
+  },
+  ref_type: {
+    320: '200',
+    410: '210',
+  },
+  req_attrs: {
+    410: ':MULTI:',
+  },
+  arr_type: {
+    411: '1',
+  },
+  reqs: {
+    285: {
+      320: 'ACME',
+      ref_320: '200:42',
+      410: 'Urgent, External',
+      ref_410: '210:7,8',
+      411: '3',
+    },
+  },
+}
+
+const objectEditResponse = {
+  obj: { id: '285', typ: '110', val: 'Contract A', up: '1' },
+  metadata: objectListResponse.type,
+  reqs: {
+    320: 'ACME',
+    410: 'Urgent, External',
+    411: '3',
+  },
+  arr_type: objectListResponse.arr_type,
+}
+
+const metadataResponse = {
+  type: objectListResponse.type,
+  reqs: [
+    { id: '320', val: 'Client', type: '3', ref: '200', reft: '200', attrs: '' },
+    { id: '410', val: 'Tags', type: '3', ref: '210', reft: '210', attrs: ':MULTI:' },
+    { id: '411', val: 'Tasks', type: '4', attrs: '' },
+  ],
+}
+
+const dictionaryResponse = {
+  110: 'Contracts',
+  200: 'Clients',
+  210: 'Tags',
+}
+
 /**
  * Console error collector.
  * Ignores known noise: deprecation warnings, source-map warnings,
@@ -37,48 +112,67 @@ function collectErrors(page: Page): ConsoleMessage[] {
 }
 
 /** Wait for the page to settle after navigation */
-async function waitForSettle(page: Page, ms = 3000) {
+async function waitForSettle(page: Page, ms = 1500) {
   // Wait for network to be idle OR timeout
   await Promise.race([
     page.waitForLoadState('networkidle').catch(() => {}),
     page.waitForTimeout(ms),
   ])
   // Extra settle time for Vue rendering
-  await page.waitForTimeout(500)
+  await page.waitForTimeout(250)
 }
 
-// ─── Login helper ────────────────────────────────────────────────
-async function login(page: Page) {
-  await page.goto('/login')
-  await page.waitForSelector('#database')
+async function installApiMocks(page: Page) {
+  await page.route('**/api/my/**', async (route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname
 
-  // Show server selector
-  const serverToggle = page.locator('a:has-text("сервер"), a:has-text("server")')
-  if (await serverToggle.count() > 0) {
-    await serverToggle.first().click()
-    await page.waitForTimeout(300)
-  }
+    let body: unknown = {}
+    if (path.includes('/dict')) {
+      body = dictionaryResponse
+    } else if (path.includes('/metadata/')) {
+      body = metadataResponse
+    } else if (path.includes('/edit_obj/')) {
+      body = objectEditResponse
+    } else if (path.includes('/object/285')) {
+      body = {}
+    } else if (path.includes('/object/')) {
+      body = objectListResponse
+    } else if (path.includes('/xsrf')) {
+      body = { token: 'test-token', _xsrf: 'test-xsrf', id: '1', user: 'tester' }
+    }
 
-  // Fill database
-  const dbInput = page.locator('#database')
-  await dbInput.clear()
-  await dbInput.fill('my')
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+  })
+}
 
-  // Fill login
-  const loginInput = page.locator('#login')
-  await loginInput.clear()
-  await loginInput.fill('d')
-
-  // Fill password — PrimeVue Password component wraps an input
-  const pwdInput = page.locator('#password').locator('input').first()
-  await pwdInput.clear()
-  await pwdInput.fill('d')
-
-  // Submit
-  await page.locator('button[type="submit"]').click()
-
-  // Wait for redirect to /my/
-  await page.waitForURL('**/my/**', { timeout: 15_000 })
+async function authenticateForRoutes(page: Page) {
+  await installApiMocks(page)
+  await page.addInitScript(() => {
+    const session = {
+      database: 'my',
+      token: 'test-token',
+      xsrfToken: 'test-xsrf',
+      userId: '1',
+      userName: 'tester',
+      userRole: 'admin',
+      authServer: 'http://localhost:3000',
+      authDatabase: 'my',
+    }
+    localStorage.setItem('integram_server', 'http://localhost:3000')
+    localStorage.setItem('integram_session', JSON.stringify(session))
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('_xsrf', 'test-xsrf')
+    localStorage.setItem('user', 'tester')
+    localStorage.setItem('id', '1')
+    localStorage.setItem('db', 'my')
+  })
+  await page.goto('/my/')
+  await page.waitForURL('**/my/**')
 }
 
 // ─── Tests ───────────────────────────────────────────────────────
@@ -90,8 +184,7 @@ test.describe('Route smoke tests', () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
-    // Login once, reuse session for all route tests
-    await login(page)
+    await authenticateForRoutes(page)
   })
 
   test.afterAll(async () => {
@@ -173,16 +266,17 @@ test.describe('Route smoke tests', () => {
   })
 
   // 6. /my/object/{typeId}
-  test('6. /my/object/{typeId} loads without errors', async () => {
+  test('6. /my/object/{typeId} deep link loads without errors', async () => {
     const id = typeId || '1'
     const errors = collectErrors(page)
     await page.goto(`/my/object/${id}`)
     await waitForSettle(page)
+    await expect(page).toHaveURL(new RegExp(`/my/object/${id}(?:[?#].*)?$`))
     expect(errors.map(e => e.text())).toEqual([])
   })
 
   // 7. /my/edit_obj/{objectId} — extract objectId from object view
-  test('7. /my/edit_obj/{objectId} loads without errors', async () => {
+  test('7. /my/edit_obj/{objectId} deep link loads without errors', async () => {
     // Navigate to object view to find an objectId
     const id = typeId || '1'
     await page.goto(`/my/object/${id}`)
@@ -213,6 +307,7 @@ test.describe('Route smoke tests', () => {
     const errors = collectErrors(page)
     await page.goto(`/my/edit_obj/${objectId}`)
     await waitForSettle(page)
+    await expect(page).toHaveURL(new RegExp(`/my/edit_obj/${objectId}(?:[?#].*)?$`))
     expect(errors.map(e => e.text())).toEqual([])
   })
 

--- a/src/components/integram/IntegramObjectList.vue
+++ b/src/components/integram/IntegramObjectList.vue
@@ -202,7 +202,7 @@
           <Column field="id" header="ID" :sortable="true" style="width: 80px">
             <template #body="{ data }">
               <router-link
-                :to="`/${database}/edit/${data.id}`"
+                :to="`/${database}/edit_obj/${data.id}`"
                 class="text-primary font-semibold"
               >
                 #{{ data.id }}
@@ -235,7 +235,7 @@
                 :title="$t('doubleClickToEdit')"
               >
                 <router-link
-                  :to="`/${database}/edit/${data.id}`"
+                  :to="`/${database}/edit_obj/${data.id}`"
                   class="text-primary"
                 >
                   {{ data.val }}
@@ -297,15 +297,23 @@
               <!-- Display Mode -->
               <div
                 v-else
-                @dblclick="startInlineEdit(data, col.field, data[col.field], col)"
+                @dblclick="!col.isArray && !col.isReference && startInlineEdit(data, col.field, data[col.field], col)"
                 class="inline-edit-trigger"
                 :title="$t('doubleClickToEdit')"
               >
-                <span v-if="col.isReference">
-                  <Tag v-if="data[col.field]" severity="info">
-                    {{ data[col.field] }}
-                  </Tag>
-                </span>
+                <ObjectValueCell
+                  v-if="col.isReference || col.isArray"
+                  :database="database"
+                  :object-id="data.id"
+                  :requisite="{
+                    id: col.requisiteId,
+                    refType: col.refTypeId,
+                    arrType: col.isArray ? (col.arrType || col.requisiteId) : null,
+                    isMulti: col.isMulti
+                  }"
+                  :raw-value="data[col.field]"
+                  :reference-value="data[`ref_${col.requisiteId}`]"
+                />
                 <span v-else-if="col.isBoolean">
                   <i
                     :class="data[col.field] ? 'fi fi-rr-check text-green-500' : 'fi fi-rr-cross-small text-red-500'"
@@ -769,7 +777,9 @@ import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 
 import integramApiClient from '@/services/integramApiClient'
+import ObjectValueCell from './ObjectValueCell.vue'
 import QuickEditModal from './QuickEditModal.vue'
+import { normalizeObjectListResponse } from './objectListCompat'
 
 // PrimeVue Components
 
@@ -1168,15 +1178,14 @@ async function loadData() {
 
     // Load object list
     const response = await integramApiClient.getObjectList(props.typeId, filterParams)
+    const normalized = normalizeObjectListResponse(response)
 
     // Parse response manually (integramApiClient returns raw response)
-    typeInfo.value = response.type
+    typeInfo.value = normalized.type
 
     // Build objects array from API response
-    const objectsList = response.object || []
-    const reqs = response.reqs || {}
-    const reqOrder = response.req_order || []
-    const reqType = response.req_type || {}
+    const objectsList = normalized.objects
+    const reqs = normalized.reqs
 
     objects.value = objectsList.map(obj => {
       const row = {
@@ -1189,7 +1198,11 @@ async function loadData() {
       // Add requisite values
       if (reqs[obj.id]) {
         for (const [reqId, reqVal] of Object.entries(reqs[obj.id])) {
-          row[`req_${reqId}`] = reqVal
+          if (String(reqId).startsWith('ref_')) {
+            row[reqId] = reqVal
+          } else {
+            row[`req_${reqId}`] = reqVal
+          }
         }
       }
 
@@ -1197,17 +1210,20 @@ async function loadData() {
     })
 
     // Build requisite columns
-    const columns = []
-    if (reqOrder) {
-      for (const reqId of reqOrder) {
-        columns.push({
-          field: `req_${reqId}`,
-          header: reqType[reqId] || `Field ${reqId}`,
-          sortable: true
-        })
-      }
-    }
-    requisiteColumns.value = columns
+    requisiteColumns.value = normalized.requisites.map(req => ({
+      field: `req_${req.id}`,
+      header: req.val,
+      sortable: true,
+      requisiteId: req.id,
+      mandatory: req.attrs?.includes(':!NULL:') || false,
+      isMulti: req.isMulti,
+      isReference: Boolean(req.refType),
+      refTypeId: req.refType,
+      isBoolean: req.base === 'BOOLEAN' || String(req.baseId) === '7',
+      isArray: Boolean(req.arrType),
+      arrType: req.arrType,
+      baseType: req.base
+    }))
 
     // Load metadata to get array fields
     await loadMetadata()
@@ -1243,11 +1259,18 @@ async function loadMetadata() {
     if (metadata && metadata.reqs) {
       // Find array/subordinate fields
       const arrays = metadata.reqs.filter(req => req.type === '4') // Array type
-      arrayColumns.value = arrays.map(req => ({
-        id: req.id,
-        name: req.val,
-        count: {} // Will be populated from API
-      }))
+      const listedArrayIds = new Set(
+        requisiteColumns.value
+          .filter(col => col.isArray)
+          .map(col => String(col.requisiteId))
+      )
+      arrayColumns.value = arrays
+        .filter(req => !listedArrayIds.has(String(req.id)))
+        .map(req => ({
+          id: req.id,
+          name: req.val,
+          count: {} // Will be populated from API
+        }))
 
       // Find filterable fields
       filterableFields.value = metadata.reqs
@@ -1287,18 +1310,21 @@ async function loadMetadata() {
 
           // Check if reference column (type is numeric and > 100, indicating table ID)
           const typeNum = parseInt(reqMeta.type)
-          const isReference = reqMeta.reft && reqMeta.reft !== '0' && typeNum > 100
+          const metadataReference = reqMeta.reft && reqMeta.reft !== '0' && typeNum > 100
+          const isReference = col.isReference || metadataReference
+          const refTypeId = col.refTypeId || (metadataReference ? reqMeta.reft || reqMeta.type : null)
 
           return {
             ...col,
             requisiteId: reqId,
             header: alias || reqMeta.val || col.header,
-            mandatory: isNotNull,
-            isMulti: isMulti,
+            mandatory: col.mandatory || isNotNull,
+            isMulti: col.isMulti || isMulti,
             isReference: isReference,
-            refTypeId: isReference ? reqMeta.reft || reqMeta.type : null,
-            isBoolean: reqMeta.type === '7',
-            isArray: reqMeta.type === '4',
+            refTypeId,
+            isBoolean: col.isBoolean || reqMeta.type === '7',
+            isArray: col.isArray || reqMeta.type === '4',
+            arrType: col.arrType || (reqMeta.type === '4' ? reqId : null),
             baseType: reqMeta.type
           }
         }
@@ -1344,7 +1370,7 @@ function onRowContextMenu(event) {
 }
 
 function editObject(obj) {
-  router.push(`/${props.database}/edit/${obj.id}`)
+  router.push(`/${props.database}/edit_obj/${obj.id}`)
 }
 
 function quickEditObject(obj) {

--- a/src/components/integram/ObjectValueCell.vue
+++ b/src/components/integram/ObjectValueCell.vue
@@ -1,0 +1,95 @@
+<template>
+  <span v-if="cell.kind === 'multi-reference'" class="object-value-cell object-value-cell-multi">
+    <template v-for="item in cell.items" :key="item.id || item.text">
+      <router-link
+        v-if="item.href"
+        :to="item.href"
+        class="object-value-link object-value-chip"
+      >
+        {{ item.text }}
+      </router-link>
+      <span v-else class="object-value-chip">
+        {{ item.text }}
+      </span>
+    </template>
+  </span>
+
+  <router-link
+    v-else-if="cell.href"
+    :to="cell.href"
+    class="object-value-link"
+  >
+    {{ cell.text }}
+  </router-link>
+
+  <span v-else class="object-value-cell">
+    {{ cell.text }}
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { buildRequisiteCell } from './objectListCompat';
+
+const props = defineProps({
+  database: {
+    type: String,
+    required: true
+  },
+  objectId: {
+    type: [String, Number],
+    required: true
+  },
+  requisite: {
+    type: Object,
+    required: true
+  },
+  rawValue: {
+    type: [String, Number, Boolean, Array, Object],
+    default: ''
+  },
+  referenceValue: {
+    type: [String, Number, Array, Object],
+    default: ''
+  }
+});
+
+const cell = computed(() => buildRequisiteCell(props));
+</script>
+
+<style scoped>
+.object-value-cell {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.25rem;
+}
+
+.object-value-cell-multi {
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.object-value-link {
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.object-value-link:hover {
+  text-decoration: underline;
+}
+
+.object-value-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: var(--surface-100);
+  color: var(--text-color);
+  padding: 0.125rem 0.5rem;
+  line-height: 1.25;
+}
+
+.object-value-link.object-value-chip {
+  color: var(--primary-color);
+}
+</style>

--- a/src/components/integram/__fixtures__/objectResponses.js
+++ b/src/components/integram/__fixtures__/objectResponses.js
@@ -1,0 +1,67 @@
+export const ordinaryObjectListResponse = {
+  type: { id: '101', val: 'Projects', up: '0' },
+  object: [
+    { id: '201', val: 'Apollo', ord: 1, up: '1' }
+  ],
+  req_order: ['301', '302'],
+  req_type: {
+    301: 'Status',
+    302: 'Budget'
+  },
+  req_base: {
+    301: 'SHORT',
+    302: 'NUMBER'
+  },
+  reqs: {
+    201: {
+      301: 'Active',
+      302: '1000'
+    }
+  }
+};
+
+export const referencedObjectListResponse = {
+  type: { id: '110', val: 'Contracts', up: '0' },
+  object: [
+    { id: '285', val: 'Contract A', ord: 1, up: '1' }
+  ],
+  req_order: ['320', '410', '411'],
+  req_type: {
+    320: 'Client',
+    410: 'Tags',
+    411: 'Tasks'
+  },
+  req_base: {
+    320: 'SHORT',
+    410: 'SHORT',
+    411: 'ARRAY'
+  },
+  ref_type: {
+    320: '200',
+    410: '210'
+  },
+  req_attrs: {
+    410: ':MULTI:'
+  },
+  arr_type: {
+    411: '1'
+  },
+  reqs: {
+    285: {
+      320: 'ACME',
+      ref_320: '200:42',
+      410: 'Urgent, External',
+      ref_410: '210:7,8',
+      411: '3'
+    }
+  }
+};
+
+export const emptyObjectListResponse = {
+  type: { id: '120', val: 'Empty table', up: '0' },
+  object: [],
+  req_order: [],
+  req_type: {},
+  req_base: {},
+  reqs: {}
+};

--- a/src/components/integram/__tests__/ObjectValueCell.spec.js
+++ b/src/components/integram/__tests__/ObjectValueCell.spec.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ObjectValueCell from '../ObjectValueCell.vue';
+import {
+  getObjectReferenceValue,
+  getObjectRequisiteValue,
+  normalizeObjectListResponse
+} from '../objectListCompat';
+import {
+  ordinaryObjectListResponse,
+  referencedObjectListResponse
+} from '../__fixtures__/objectResponses';
+
+const RouterLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>'
+};
+
+function mountCell(props) {
+  return mount(ObjectValueCell, {
+    props,
+    global: {
+      stubs: {
+        RouterLink: RouterLinkStub
+      }
+    }
+  });
+}
+
+describe('ObjectValueCell', () => {
+  it('renders ordinary values as text', () => {
+    const normalized = normalizeObjectListResponse(ordinaryObjectListResponse);
+    const req = normalized.requisites[0];
+
+    const wrapper = mountCell({
+      database: 'my',
+      objectId: '201',
+      requisite: req,
+      rawValue: getObjectRequisiteValue(normalized.reqs, '201', req.id)
+    });
+
+    expect(wrapper.text()).toBe('Active');
+    expect(wrapper.find('a').exists()).toBe(false);
+  });
+
+  it('renders single reference values as legacy object-filter links', () => {
+    const normalized = normalizeObjectListResponse(referencedObjectListResponse);
+    const req = normalized.requisites[0];
+
+    const wrapper = mountCell({
+      database: 'my',
+      objectId: '285',
+      requisite: req,
+      rawValue: getObjectRequisiteValue(normalized.reqs, '285', req.id),
+      referenceValue: getObjectReferenceValue(normalized.reqs, '285', req.id)
+    });
+
+    expect(wrapper.find('a').attributes('href')).toBe('/my/object/200?F_I=42');
+    expect(wrapper.text()).toBe('ACME');
+  });
+
+  it('renders multiselect references as separate links', () => {
+    const normalized = normalizeObjectListResponse(referencedObjectListResponse);
+    const req = normalized.requisites[1];
+
+    const wrapper = mountCell({
+      database: 'my',
+      objectId: '285',
+      requisite: req,
+      rawValue: getObjectRequisiteValue(normalized.reqs, '285', req.id),
+      referenceValue: getObjectReferenceValue(normalized.reqs, '285', req.id)
+    });
+
+    const links = wrapper.findAll('a');
+    expect(links.map(link => link.attributes('href'))).toEqual([
+      '/my/object/210?F_I=7',
+      '/my/object/210?F_I=8'
+    ]);
+    expect(links.map(link => link.text())).toEqual(['Urgent', 'External']);
+  });
+
+  it('renders subordinate columns as parent-filter links', () => {
+    const normalized = normalizeObjectListResponse(referencedObjectListResponse);
+    const req = normalized.requisites[2];
+
+    const wrapper = mountCell({
+      database: 'my',
+      objectId: '285',
+      requisite: req,
+      rawValue: getObjectRequisiteValue(normalized.reqs, '285', req.id)
+    });
+
+    expect(wrapper.find('a').attributes('href')).toBe('/my/object/411?F_U=285');
+    expect(wrapper.text()).toBe('(3)');
+  });
+});

--- a/src/components/integram/__tests__/objectListCompat.spec.js
+++ b/src/components/integram/__tests__/objectListCompat.spec.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildObjectEditHref,
+  buildObjectListHref,
+  buildRequisiteCell,
+  getObjectReferenceValue,
+  getObjectRequisiteValue,
+  normalizeObjectListResponse
+} from '../objectListCompat';
+import {
+  emptyObjectListResponse,
+  ordinaryObjectListResponse,
+  referencedObjectListResponse
+} from '../__fixtures__/objectResponses';
+
+describe('object list legacy compatibility helpers', () => {
+  it('normalizes an ordinary object list fixture', () => {
+    const normalized = normalizeObjectListResponse(ordinaryObjectListResponse);
+
+    expect(normalized.type.val).toBe('Projects');
+    expect(normalized.objects).toHaveLength(1);
+    expect(normalized.requisites.map(req => req.val)).toEqual(['Status', 'Budget']);
+    expect(getObjectRequisiteValue(normalized.reqs, '201', '301')).toBe('Active');
+  });
+
+  it('normalizes reference and subordinate metadata from legacy JSON', () => {
+    const normalized = normalizeObjectListResponse(referencedObjectListResponse);
+
+    expect(normalized.requisites[0]).toMatchObject({ id: '320', refType: '200', isMulti: false });
+    expect(normalized.requisites[1]).toMatchObject({ id: '410', refType: '210', isMulti: true });
+    expect(normalized.requisites[2]).toMatchObject({ id: '411', arrType: '411' });
+    expect(getObjectReferenceValue(normalized.reqs, '285', '320')).toBe('200:42');
+  });
+
+  it('keeps empty object lists renderable', () => {
+    const normalized = normalizeObjectListResponse(emptyObjectListResponse);
+
+    expect(normalized.objects).toEqual([]);
+    expect(normalized.requisites).toEqual([]);
+    expect(normalized.reqs).toEqual({});
+  });
+
+  it('builds legacy-compatible object and card URLs', () => {
+    expect(buildObjectListHref('my', '200', { F_I: 42 })).toBe('/my/object/200?F_I=42');
+    expect(buildObjectListHref('my', '411', { F_U: 285 })).toBe('/my/object/411?F_U=285');
+    expect(buildObjectEditHref('my', 285)).toBe('/my/edit_obj/285');
+  });
+
+  it('formats a reference cell with the referenced object filter link', () => {
+    const normalized = normalizeObjectListResponse(referencedObjectListResponse);
+    const req = normalized.requisites[0];
+
+    const cell = buildRequisiteCell({
+      database: 'my',
+      objectId: '285',
+      requisite: req,
+      rawValue: getObjectRequisiteValue(normalized.reqs, '285', req.id),
+      referenceValue: getObjectReferenceValue(normalized.reqs, '285', req.id)
+    });
+
+    expect(cell).toMatchObject({
+      kind: 'reference',
+      text: 'ACME',
+      href: '/my/object/200?F_I=42'
+    });
+  });
+});

--- a/src/components/integram/objectListCompat.js
+++ b/src/components/integram/objectListCompat.js
@@ -1,0 +1,229 @@
+function hasOwn(map, key) {
+  return Object.prototype.hasOwnProperty.call(map, key);
+}
+
+function getByKey(map, key) {
+  if (!map || key === null || key === undefined) return undefined;
+
+  if (hasOwn(map, key)) return map[key];
+
+  const stringKey = String(key);
+  if (hasOwn(map, stringKey)) return map[stringKey];
+
+  if (/^\d+$/.test(stringKey)) {
+    const numberKey = Number(stringKey);
+    if (hasOwn(map, numberKey)) return map[numberKey];
+  }
+
+  return undefined;
+}
+
+function cleanId(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function isLikelyObjectId(value) {
+  return /^\d+$/.test(cleanId(value));
+}
+
+export function getDisplayText(value) {
+  if (value === null || value === undefined) return '';
+
+  if (Array.isArray(value)) {
+    return value.map(getDisplayText).filter(Boolean).join(', ');
+  }
+
+  if (typeof value === 'object') {
+    const display = value.displayValue ?? value.display ?? value.text ?? value.name ?? value.val ?? value.value;
+    if (display !== undefined && display !== value) return getDisplayText(display);
+    if (value.id !== undefined) return cleanId(value.id);
+    return '';
+  }
+
+  return String(value);
+}
+
+function getReferenceIdFromValue(value) {
+  if (value === null || value === undefined) return '';
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return cleanId(value.dirRowId ?? value.rowId ?? value.objectId ?? value.ref ?? value.id ?? value.value);
+  }
+
+  return isLikelyObjectId(value) ? cleanId(value) : '';
+}
+
+function splitDisplayValues(value) {
+  if (Array.isArray(value)) return value.map(getDisplayText).filter(Boolean);
+
+  const text = getDisplayText(value);
+  if (!text) return [];
+
+  return text.split(',').map(item => item.trim()).filter(Boolean);
+}
+
+export function parseReferenceValue(referenceValue, fallbackTableId = null) {
+  let tableId = cleanId(fallbackTableId) || null;
+  let ids = [];
+
+  if (referenceValue === null || referenceValue === undefined || referenceValue === '') {
+    return { tableId, ids };
+  }
+
+  if (Array.isArray(referenceValue)) {
+    ids = referenceValue.map(getReferenceIdFromValue).filter(Boolean);
+    return { tableId, ids };
+  }
+
+  if (typeof referenceValue === 'object') {
+    tableId = cleanId(
+      referenceValue.tableId ??
+      referenceValue.typeId ??
+      referenceValue.refType ??
+      referenceValue.refTableId ??
+      tableId
+    ) || tableId;
+
+    const rowIds = referenceValue.rowIds ?? referenceValue.ids ?? referenceValue.values;
+    if (Array.isArray(rowIds)) {
+      ids = rowIds.map(getReferenceIdFromValue).filter(Boolean);
+    } else {
+      const id = getReferenceIdFromValue(referenceValue);
+      if (id) ids = [id];
+    }
+
+    return { tableId, ids };
+  }
+
+  const text = cleanId(referenceValue);
+  const separatorIndex = text.indexOf(':');
+
+  if (separatorIndex >= 0) {
+    tableId = cleanId(text.slice(0, separatorIndex)) || tableId;
+    ids = text.slice(separatorIndex + 1).split(',').map(cleanId).filter(Boolean);
+  } else {
+    ids = text.split(',').map(cleanId).filter(Boolean);
+  }
+
+  return { tableId, ids };
+}
+
+export function buildObjectListHref(database, typeId, query = {}) {
+  const path = `/${encodeURIComponent(database)}/object/${encodeURIComponent(typeId)}`;
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== null && value !== undefined && value !== '') {
+      params.set(key, String(value));
+    }
+  }
+
+  const search = params.toString();
+  return search ? `${path}?${search}` : path;
+}
+
+export function buildObjectEditHref(database, objectId) {
+  return `/${encodeURIComponent(database)}/edit_obj/${encodeURIComponent(objectId)}`;
+}
+
+export function normalizeObjectListResponse(response = {}) {
+  const reqType = response.req_type || {};
+  const reqOrder = Array.isArray(response.req_order)
+    ? response.req_order
+    : Object.keys(reqType);
+
+  const requisites = reqOrder.map(reqId => {
+    const id = cleanId(reqId);
+    const attrs = getByKey(response.req_attrs, id) || '';
+    const refType = getByKey(response.ref_type, id) || null;
+    const arrType = getByKey(response.arr_type, id) ? id : null;
+
+    return {
+      id,
+      val: getByKey(reqType, id) || `Req ${id}`,
+      base: getByKey(response.req_base, id) || 'TEXT',
+      baseId: getByKey(response.req_base_id, id),
+      refType,
+      arrType,
+      isMulti: attrs.includes(':MULTI:'),
+      attrs
+    };
+  });
+
+  return {
+    type: response.type || null,
+    objects: Array.isArray(response.object) ? response.object : [],
+    reqs: response.reqs || {},
+    requisites
+  };
+}
+
+export function getObjectRequisiteValue(reqs, objectId, requisiteId) {
+  const row = getByKey(reqs, objectId) || {};
+  return getByKey(row, requisiteId) ?? '';
+}
+
+export function getObjectReferenceValue(reqs, objectId, requisiteId) {
+  const row = getByKey(reqs, objectId) || {};
+  return getByKey(row, `ref_${requisiteId}`) ?? '';
+}
+
+export function buildRequisiteCell({ database, objectId, requisite, rawValue, referenceValue }) {
+  const valueText = getDisplayText(rawValue);
+
+  if (requisite?.arrType) {
+    const count = valueText === '' ? '0' : valueText;
+    return {
+      kind: 'nested',
+      text: `(${count})`,
+      href: buildObjectListHref(database, requisite.arrType, { F_U: objectId })
+    };
+  }
+
+  if (requisite?.refType) {
+    const reference = parseReferenceValue(referenceValue, requisite.refType);
+    const displayValues = splitDisplayValues(rawValue);
+    let ids = reference.ids;
+
+    if (ids.length === 0 && Array.isArray(rawValue)) {
+      ids = rawValue.map(getReferenceIdFromValue).filter(Boolean);
+    } else if (ids.length === 0) {
+      const fallbackId = getReferenceIdFromValue(rawValue);
+      if (fallbackId) ids = [fallbackId];
+    }
+
+    const items = ids.map((id, index) => ({
+      id,
+      text: displayValues[index] || id,
+      href: reference.tableId
+        ? buildObjectListHref(database, reference.tableId, { F_I: id })
+        : null
+    }));
+
+    if (items.length === 0 && valueText) {
+      items.push({ id: null, text: valueText, href: null });
+    }
+
+    if (requisite.isMulti) {
+      return {
+        kind: 'multi-reference',
+        text: items.map(item => item.text).join(', '),
+        items
+      };
+    }
+
+    const item = items[0] || { text: valueText, href: null };
+    return {
+      kind: 'reference',
+      text: item.text || '',
+      href: item.href
+    };
+  }
+
+  return {
+    kind: valueText ? 'text' : 'empty',
+    text: valueText,
+    href: null
+  };
+}

--- a/src/views/integram/IntegramObjectView.vue
+++ b/src/views/integram/IntegramObjectView.vue
@@ -242,9 +242,9 @@
               <template #body="slotProps">
                 <div
                   :class="{
-                    'editable-cell': inlineEditEnabled,
+                    'editable-cell': inlineEditEnabled && !req.arrType,
                     'editing': editingCell?.rowId === slotProps.data.id && editingCell?.field === `req_${req.id}`,
-                    'cell-dir': req.refType
+                    'cell-dir': req.refType || req.arrType
                   }"
                   @click="handleCellClick(slotProps.data, `req_${req.id}`, getRequisiteValue(slotProps.data.id, req.id), req.base || 'TEXT', req)"
                 >
@@ -361,9 +361,14 @@
                     <span v-else-if="req.base === 'BOOLEAN'">
                       {{ getRequisiteValue(slotProps.data.id, req.id) === 'X' ? '✓' : '' }}
                     </span>
-                    <span v-else :class="{ 'dir': req.refType }">
-                      {{ getRequisiteValue(slotProps.data.id, req.id) }}
-                    </span>
+                    <ObjectValueCell
+                      v-else
+                      :database="database"
+                      :object-id="slotProps.data.id"
+                      :requisite="req"
+                      :raw-value="getRequisiteValue(slotProps.data.id, req.id)"
+                      :reference-value="getReferenceValue(slotProps.data.id, req.id)"
+                    />
                   </template>
                 </div>
               </template>
@@ -520,8 +525,8 @@
         </div>
 
         <!-- Requisites -->
-        <Divider v-if="requisites.length > 0" />
-        <div v-for="req in requisites" :key="req.id" class="field">
+        <Divider v-if="editableRequisites.length > 0" />
+        <div v-for="req in editableRequisites" :key="req.id" class="field">
           <label :for="'req_' + req.id">{{ req.val }}</label>
 
           <!-- GRANT type - special dropdown -->
@@ -795,6 +800,13 @@ import { useIntegramSession } from '@/composables/useIntegramSession';
 import { useGrants } from '@/composables/useGrants';
 import integramApiClient from '@/services/integramApiClient';
 import IntegramBreadcrumb from '@/components/integram/IntegramBreadcrumb.vue';
+import ObjectValueCell from '@/components/integram/ObjectValueCell.vue';
+import {
+  getObjectReferenceValue,
+  getObjectRequisiteValue,
+  normalizeObjectListResponse,
+  parseReferenceValue
+} from '@/components/integram/objectListCompat';
 
 // PrimeVue Components
 
@@ -925,6 +937,8 @@ const isAddColumnFormValid = computed(() => {
   return addColumnForm.value.name.trim().length > 0 && addColumnForm.value.baseTypeId;
 });
 
+const editableRequisites = computed(() => requisites.value.filter(req => !req.arrType));
+
 const filteredObjects = computed(() => {
   if (!hasActiveFilters.value) {
     return objectsList.value;
@@ -940,7 +954,7 @@ const filteredObjects = computed(() => {
     for (const key in filters.value) {
       if (key.startsWith('req_') && filters.value[key]) {
         const reqId = key.replace('req_', '');
-        const value = getRequisiteValue(obj.id, reqId);
+        const value = String(getRequisiteValue(obj.id, reqId) ?? '');
         if (!value || !value.toLowerCase().includes(filters.value[key].toLowerCase())) {
           return false;
         }
@@ -979,18 +993,20 @@ async function loadObjects(page = 1, append = false) {
     }
 
     const data = await integramApiClient.getObjectList(typeId.value, queryFilters);
+    const normalized = normalizeObjectListResponse(data);
     objectsData.value = data;
-    typeData.value = data.type;
+    typeData.value = normalized.type;
+    requisites.value = normalized.requisites;
 
     // Append mode: add to existing list
     if (append && infiniteScrollEnabled.value) {
-      const newObjects = data.object || [];
+      const newObjects = normalized.objects;
       if (newObjects.length === 0) {
         hasMoreData.value = false;
       } else {
         objectsList.value = [...objectsList.value, ...newObjects];
         // Merge requisites data
-        const newReqs = data.reqs || {};
+        const newReqs = normalized.reqs;
         requisitesData.value = { ...requisitesData.value, ...newReqs };
 
         // Check if we got less than requested - means no more data
@@ -1000,9 +1016,9 @@ async function loadObjects(page = 1, append = false) {
       }
     } else {
       // Replace mode
-      objectsList.value = data.object || [];
-      requisitesData.value = data.reqs || {};
-      hasMoreData.value = (data.object || []).length >= rowsPerPage.value;
+      objectsList.value = normalized.objects;
+      requisitesData.value = normalized.reqs;
+      hasMoreData.value = normalized.objects.length >= rowsPerPage.value;
     }
 
     // Update current page from response if available
@@ -1016,10 +1032,10 @@ async function loadObjects(page = 1, append = false) {
     } else {
       // Fallback: estimate based on current data
       // If we got a full page, assume there might be more
-      if ((data.object || []).length >= rowsPerPage.value) {
-        totalObjects.value = (data.object || []).length * 2; // Conservative estimate
+      if (normalized.objects.length >= rowsPerPage.value) {
+        totalObjects.value = normalized.objects.length * 2; // Conservative estimate
       } else {
-        totalObjects.value = (data.object || []).length;
+        totalObjects.value = normalized.objects.length;
       }
     }
 
@@ -1028,24 +1044,11 @@ async function loadObjects(page = 1, append = false) {
       totalPages.value = data.total_pages;
     } else if (rowsPerPage.value > 0 && totalObjects.value > 0) {
       totalPages.value = Math.ceil(totalObjects.value / rowsPerPage.value);
-    } else if ((data.object || []).length >= rowsPerPage.value) {
+    } else if (normalized.objects.length >= rowsPerPage.value) {
       // If we got a full page, assume there's at least one more page
       totalPages.value = page + 1;
     } else {
       totalPages.value = page;
-    }
-
-    // Extract requisites from response
-    if (data.req_type && data.req_order) {
-      requisites.value = data.req_order.map(reqId => ({
-        id: reqId,
-        val: data.req_type[reqId] || `Req ${reqId}`,
-        base: data.req_base?.[reqId] || 'TEXT',
-        baseId: data.req_base_id?.[reqId],
-        // Reference/directory type support
-        refType: data.ref_type?.[reqId] || null,
-        isMulti: data.req_attrs?.[reqId]?.includes(':MULTI:') || false
-      }));
     }
   } catch (err) {
     error.value = err.message;
@@ -1061,7 +1064,11 @@ async function loadObjects(page = 1, append = false) {
 }
 
 function getRequisiteValue(objectId, requisiteId) {
-  return requisitesData.value[objectId]?.[requisiteId] || '';
+  return getObjectRequisiteValue(requisitesData.value, objectId, requisiteId);
+}
+
+function getReferenceValue(objectId, requisiteId) {
+  return getObjectReferenceValue(requisitesData.value, objectId, requisiteId);
 }
 
 function clearFilters() {
@@ -1185,6 +1192,7 @@ async function handleCellClick(rowData, field, value, baseType, req = null) {
 
   // Don't allow editing ID or certain system fields
   if (field === 'id') return;
+  if (req?.arrType) return;
 
   editingCell.value = {
     rowId: rowData.id,
@@ -1196,13 +1204,8 @@ async function handleCellClick(rowData, field, value, baseType, req = null) {
   // If this is a reference field, load options
   if (req?.refType) {
     await loadReferenceOptions(req.refType);
-    // For reference fields, store the current value (object ID) if available
-    // The display text is shown, but we need the ID for saving
-    const objectId = rowData.id;
-    const reqId = req.id;
-    // Try to get the actual object ID from reqs data
-    const rawValue = requisitesData.value[objectId]?.[reqId];
-    editingValue.value = rawValue || '';
+    const reference = parseReferenceValue(getReferenceValue(rowData.id, req.id), req.refType);
+    editingValue.value = reference.ids[0] || '';
   } else if (baseType === 'BOOLEAN') {
     editingValue.value = value === 'X';
   } else if (baseType === 'DATE' || baseType === 'DATETIME') {
@@ -1293,7 +1296,16 @@ async function saveEdit(rowData, reqId = null) {
       if (!requisitesData.value[rowData.id]) {
         requisitesData.value[rowData.id] = {};
       }
-      requisitesData.value[rowData.id][reqId] = valueToSave;
+      const req = editingCell.value.req;
+      if (req?.refType) {
+        const selectedReference = referenceOptions.value[req.refType]?.find(option =>
+          String(option.id) === String(valueToSave)
+        );
+        requisitesData.value[rowData.id][reqId] = selectedReference?.val || valueToSave;
+        requisitesData.value[rowData.id][`ref_${reqId}`] = valueToSave ? `${req.refType}:${valueToSave}` : '';
+      } else {
+        requisitesData.value[rowData.id][reqId] = valueToSave;
+      }
     }
 
     toast.add({


### PR DESCRIPTION
## Summary

Fixes #17.

This PR ports the legacy object list/card behavior into the Vue Integram routes and makes the route smoke deterministic.

## Changes

- Added object-list compatibility helpers for legacy JSON fixtures, `ref_*` reference IDs, multiselect references, subordinate array/count columns, and old object/card URLs.
- Added `ObjectValueCell` to render ordinary values, reference links (`F_I`), multiselect reference links, and subordinate list links (`F_U`).
- Wired the routed object view and object-list component to preserve reference metadata and use `/edit_obj/:id` for object cards.
- Added fixtures for ordinary objects, reference/multiselect/subordinate objects, and empty lists.
- Updated Playwright route smoke to use stable mocked API data and assert deep links for `/my/object/:typeId` and `/my/edit_obj/:objectId`.

## Reproduction / Verification

- Open `/my/object/110` and verify object rows render from the legacy list payload.
- Reference values link to `/my/object/{refType}?F_I={id}`.
- Subordinate counts link to `/my/object/{subordinateType}?F_U={objectId}`.
- Object card links keep using `/my/edit_obj/{objectId}`.

## Tests

- `npm test` - passed, 4 files / 24 tests.
- `npm run build` - passed. Vite still reports the existing large chunk warning.
- `npm run test:e2e -- e2e/routes.spec.ts` - passed, 14 route smoke tests.