### PR TITLE
Fix Integram object editor field mapping

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T06:35:07.722Z for PR creation at branch issue-18-c6de048664bf for issue https://github.com/ideav/vue-gram/issues/18

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T06:35:07.722Z for PR creation at branch issue-18-c6de048664bf for issue https://github.com/ideav/vue-gram/issues/18

--- a/src/components/integram/IntegramEnhancedObjectEditor.vue
+++ b/src/components/integram/IntegramEnhancedObjectEditor.vue
@@ -221,8 +221,8 @@
                       <InputNumber
                         :id="`req_${req.id}`"
                         v-model="formData[`t${req.id}`]"
-                        :min-fraction-digits="req.baseType === 'NUMBER' ? 2 : 0"
-                        :max-fraction-digits="req.baseType === 'NUMBER' ? 2 : 0"
+                        :min-fraction-digits="req.baseType === 'SIGNED' ? 2 : 0"
+                        :max-fraction-digits="req.baseType === 'SIGNED' ? 2 : 0"
                         class="w-full"
                       />
                     </div>
@@ -408,8 +408,8 @@
                 <InputNumber
                   :id="`req_${req.id}`"
                   v-model="formData[`t${req.id}`]"
-                  :min-fraction-digits="req.baseType === 'NUMBER' ? 2 : 0"
-                  :max-fraction-digits="req.baseType === 'NUMBER' ? 2 : 0"
+                  :min-fraction-digits="req.baseType === 'SIGNED' ? 2 : 0"
+                  :max-fraction-digits="req.baseType === 'SIGNED' ? 2 : 0"
                   class="w-full"
                 />
               </div>
@@ -512,6 +512,12 @@ import { useRoute, useRouter } from 'vue-router'
 import { useToast } from 'primevue/usetoast'
 import integramService from '@/services/integramService'
 import integramApiClient from '@/services/integramApiClient'
+import {
+  getIntegramArrayTypeId,
+  getIntegramBaseType,
+  isIntegramArrayRequisite,
+  isIntegramReferenceRequisite
+} from '@/utils/integramFieldTypes'
 
 // Import PrimeVue components
 
@@ -566,6 +572,10 @@ const hasArrayFields = computed(() => {
 async function loadObject() {
   try {
     loading.value = true
+    formData.value = {}
+    requisites.value = []
+    tabs.value = []
+    customButtons.value = []
 
     // Initialize integramService session from integramApiClient if available
     const authInfo = integramApiClient.getAuthInfo()
@@ -606,12 +616,10 @@ async function loadObject() {
     if (metaData && metaData.reqs) {
       // First pass: parse all requisites
       const requisitesData = metaData.reqs.map(req => {
-        // Detect field type based on Integram type codes:
-        // Type '4' = ARRAY (subordinate table)
-        // Type with req.ref = REFERENCE (foreign key to another table)
-        // IMPORTANT: Check isArray FIRST, because ARRAY fields might also have req.ref
-        const isArray = req.type === '4' // Array type
-        const isReference = !isArray && (req.ref !== undefined)
+        // Detect array metadata before references because subordinate fields can
+        // also expose req.ref in legacy responses.
+        const isArray = isIntegramArrayRequisite(req, arrTypeMapping)
+        const isReference = isIntegramReferenceRequisite(req, arrTypeMapping)
 
         // Get current value and parse it properly
         let currentValue = null
@@ -763,7 +771,7 @@ async function loadObject() {
         let refTypeId = null
         if (isArray) {
           // For ARRAY fields: Check arr_type mapping first, then fallbacks
-          refTypeId = arrTypeMapping[req.id] || req.arr || req.arr_id || req.ref || null
+          refTypeId = getIntegramArrayTypeId(req, arrTypeMapping)
         } else {
           // For REFERENCE fields: Use req.ref
           refTypeId = req.ref || null
@@ -787,7 +795,7 @@ async function loadObject() {
         const requisiteData = {
           id: req.id,
           name: req.val,
-          baseType: getBaseType(req.type),
+          baseType: getIntegramBaseType(req.type),
           required: req.attrs && req.attrs.includes(':!NULL:'),
           multi: req.attrs && req.attrs.includes(':MULTI:'),
           isReference,
@@ -840,6 +848,12 @@ async function loadObject() {
 
     // Initialize form data
     if (response.reqs) {
+      const reqById = new Map(requisites.value.map(req => [String(req.id), req]))
+
+      const setFormValue = (reqId, value) => {
+        formData.value[`t${reqId}`] = normalizeFormValue(reqById.get(String(reqId)), value)
+      }
+
       for (const [reqId, value] of Object.entries(response.reqs)) {
         // Parse value properly - handle objects, arrays, and primitives
         // The API returns: {"type":"...", "order":"...", "value":"actual_value", "base":"...", "arr":"...", "arr_type":...}
@@ -849,13 +863,13 @@ async function loadObject() {
         if (Array.isArray(value)) {
           // For multiselect, extract the referenced object IDs (not the multiselect item IDs)
           // The array structure is: [{id: msItemId, ref: refObjectId, val: displayName}, ...]
-          formData.value[`t${reqId}`] = value.map(v => {
+          setFormValue(reqId, value.map(v => {
             if (typeof v === 'object' && v !== null) {
               // Extract based on priority: ref (for multiselect), id, value
               return v.ref || ('value' in v ? v.value : ('id' in v && 'val' in v ? v.id : ('val' in v ? v.val : ('id' in v ? v.id : JSON.stringify(v)))))
             }
             return v
-          })
+          }))
 
         }
         else if (value !== null && typeof value === 'object') {
@@ -863,36 +877,36 @@ async function loadObject() {
           // Format: {multiselect: {id: [...], val: [...], ref_val: [...]}, ...}
           if ('multiselect' in value && value.multiselect && value.multiselect.val && Array.isArray(value.multiselect.val)) {
             // Extract referenced object IDs (not multiselect item IDs)
-            formData.value[`t${reqId}`] = value.multiselect.val
+            setFormValue(reqId, value.multiselect.val)
           }
           // Check for 'value' property first (Integram API standard format)
           else if ('value' in value) {
-            formData.value[`t${reqId}`] = value.value
+            setFormValue(reqId, value.value)
           }
           // For REF fields with both 'id' and 'val', use the ID (val is the display name)
           // Format: {id: 123, val: "Display Name"}
           else if ('id' in value && 'val' in value) {
             // Use the ID for the form data (this is what gets saved)
-            formData.value[`t${reqId}`] = value.id
+            setFormValue(reqId, value.id)
           }
           // If it's an object with 'val' property only (alternative format), use that
           else if ('val' in value) {
-            formData.value[`t${reqId}`] = value.val
+            setFormValue(reqId, value.val)
           }
           // If it's an object with 'id' property only (reference), use the ID
           else if ('id' in value) {
-            formData.value[`t${reqId}`] = value.id
+            setFormValue(reqId, value.id)
           }
           // Otherwise, log warning and use empty string
           else {
             if (import.meta.env.DEV) {
               console.warn(`Unknown value format for requisite ${reqId}:`, value)
             }
-            formData.value[`t${reqId}`] = ''
+            setFormValue(reqId, '')
           }
         } else {
           // Primitive value - use as is
-          formData.value[`t${reqId}`] = value
+          setFormValue(reqId, value)
         }
       }
     }
@@ -936,27 +950,6 @@ async function loadObject() {
   }
 }
 
-function getBaseType(typeCode) {
-  const types = {
-    '3': 'SHORT',
-    '8': 'CHARS',
-    '9': 'DATE',
-    '4': 'DATETIME',
-    '13': 'SIGNED',
-    '14': 'NUMBER',
-    '11': 'BOOLEAN',
-    '12': 'MEMO',
-    '10': 'FILE',
-    '15': 'HTML',
-    '6': 'PWD',
-    '16': 'CALCULATABLE',
-    '17': 'BUTTON',
-    '18': 'PATH',
-    '19': 'REPORT_COLUMN'
-  }
-  return types[typeCode] || 'SHORT'
-}
-
 function getHintFromAttrs(attrs) {
   if (!attrs) return ''
 
@@ -965,6 +958,25 @@ function getHintFromAttrs(attrs) {
   if (attrs.includes('[NOW]')) return 'По умолчанию: текущее время'
 
   return ''
+}
+
+function normalizeBooleanValue(value) {
+  return value === true ||
+    value === 1 ||
+    value === '1' ||
+    value === 'true' ||
+    value === 'TRUE' ||
+    value === 'X' ||
+    value === 'x' ||
+    value === 'on'
+}
+
+function normalizeFormValue(req, value) {
+  if (req?.baseType === 'BOOLEAN') {
+    return normalizeBooleanValue(value)
+  }
+
+  return value
 }
 
 function getRequisitesForTab(tabId) {
@@ -1102,7 +1114,7 @@ async function saveObject() {
     // Save
     const result = await integramService.saveObject(props.objectId, formData.value)
 
-    if (result.id) {
+    if (result && !result.failed) {
       toast.add({
         severity: 'success',
         summary: 'Объект сохранен',
@@ -1130,8 +1142,8 @@ async function duplicateObject() {
     const result = await integramService.createObject(
       objectData.value.typ,
       `${objectData.value.val} (copy)`,
-      objectData.value.up,
-      formData.value
+      formData.value,
+      objectData.value.up || null
     )
 
     if (result.id) {
@@ -1143,7 +1155,7 @@ async function duplicateObject() {
       })
 
       // Navigate to new object
-      router.push(`/${props.database}/edit/${result.id}`)
+      router.push(`/${props.database}/edit_obj/${result.id}`)
     }
   } catch (error) {
     toast.add({
@@ -1185,7 +1197,7 @@ async function deleteObject() {
 async function deleteFile(reqId) {
   try {
     await integramService.setRequisites(props.objectId, {
-      [`t${reqId}`]: ''
+      [reqId]: ''
     })
 
     toast.add({

--- a/src/components/integram/__tests__/IntegramEnhancedObjectEditor.spec.js
+++ b/src/components/integram/__tests__/IntegramEnhancedObjectEditor.spec.js
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import IntegramEnhancedObjectEditor from '../IntegramEnhancedObjectEditor.vue'
+import integramService from '@/services/integramService'
+
+const push = vi.fn()
+const toastAdd = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAdd })
+}))
+
+vi.mock('@/services/integramApiClient', () => ({
+  default: {
+    getAuthInfo: vi.fn(() => ({
+      token: 'auth-token',
+      xsrf: 'xsrf-token',
+      database: 'my'
+    }))
+  }
+}))
+
+vi.mock('@/services/integramService', () => ({
+  default: {
+    setSession: vi.fn(),
+    setDatabase: vi.fn(),
+    getEditObject: vi.fn(),
+    getMetadata: vi.fn(),
+    getReferenceOptions: vi.fn(),
+    saveObject: vi.fn(),
+    createObject: vi.fn(),
+    deleteObject: vi.fn(),
+    setRequisites: vi.fn()
+  }
+}))
+
+const stubs = {
+  Card: {
+    template: '<section><slot name="title" /><slot name="content" /></section>'
+  },
+  ProgressSpinner: {
+    template: '<div data-test="spinner" />'
+  },
+  Badge: {
+    props: ['value'],
+    template: '<span><slot />{{ value }}</span>'
+  },
+  Message: {
+    template: '<div><slot /></div>'
+  },
+  Button: {
+    props: ['label'],
+    emits: ['click'],
+    template: '<button type="button" @click="$emit(\'click\', $event)"><slot />{{ label }}</button>'
+  },
+  Tabs: {
+    template: '<div><slot /></div>'
+  },
+  TabList: {
+    template: '<div><slot /></div>'
+  },
+  Tab: {
+    template: '<button><slot /></button>'
+  },
+  TabPanels: {
+    template: '<div><slot /></div>'
+  },
+  TabPanel: {
+    template: '<div><slot /></div>'
+  },
+  Divider: {
+    template: '<hr />'
+  },
+  RouterLink: {
+    template: '<a><slot /></a>'
+  },
+  ReferenceField: {
+    template: '<div data-test="reference-field" />'
+  },
+  FileField: {
+    template: '<div data-test="file-field" />'
+  },
+  DateField: {
+    template: '<div data-test="date-field" />'
+  },
+  DateTimeField: {
+    template: '<div data-test="datetime-field" />'
+  },
+  PasswordField: {
+    template: '<div data-test="password-field" />'
+  },
+  Editor: {
+    template: '<div data-test="html-editor" />'
+  },
+  Textarea: {
+    template: '<textarea data-test="memo-field" />'
+  },
+  InputText: {
+    template: '<input data-test="input-text" />'
+  },
+  InputNumber: {
+    template: '<input data-test="input-number" />'
+  },
+  Checkbox: {
+    template: '<input data-test="checkbox-field" type="checkbox" />'
+  }
+}
+
+function mountEditor() {
+  return mount(IntegramEnhancedObjectEditor, {
+    props: {
+      database: 'my',
+      objectId: 285
+    },
+    global: {
+      stubs,
+      directives: {
+        tooltip: vi.fn()
+      }
+    }
+  })
+}
+
+describe('IntegramEnhancedObjectEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    integramService.getEditObject.mockResolvedValue({
+      obj: {
+        id: 285,
+        typ: 77,
+        val: 'Editable object',
+        typ_name: 'Demo type',
+        up: '1'
+      },
+      reqs: {
+        2: '<p>HTML</p>',
+        3: 'short text',
+        4: '2026-05-09 12:30:00',
+        6: 'secret',
+        8: 'long text',
+        9: '2026-05-09',
+        10: { value: 'document.pdf', file: '/files/document.pdf' },
+        11: 'X',
+        12: 'memo text',
+        13: 100,
+        14: 12.5,
+        18: { id: 501, val: 'Reference value' },
+        90: ''
+      },
+      arr_type: {
+        90: 901
+      },
+      arrCounts: {
+        90: 3
+      }
+    })
+
+    integramService.getMetadata.mockImplementation((typeId) => {
+      if (String(typeId) === '77') {
+        return Promise.resolve({
+          reqs: [
+            { id: 2, val: 'HTML body', type: '2', attrs: '' },
+            { id: 3, val: 'Short text', type: '3', attrs: '' },
+            { id: 4, val: 'Created at', type: '4', attrs: '' },
+            { id: 6, val: 'Password', type: '6', attrs: '' },
+            { id: 8, val: 'Chars', type: '8', attrs: '' },
+            { id: 9, val: 'Due date', type: '9', attrs: '' },
+            { id: 10, val: 'Attachment', type: '10', attrs: '' },
+            { id: 11, val: 'Active', type: '11', attrs: '' },
+            { id: 12, val: 'Memo', type: '12', attrs: '' },
+            { id: 13, val: 'Integer number', type: '13', attrs: '' },
+            { id: 14, val: 'Decimal number', type: '14', attrs: '' },
+            { id: 18, val: 'Owner', type: '3', ref: 500, attrs: '' },
+            { id: 90, val: 'Lines', type: '3', arr: 901, attrs: '' }
+          ]
+        })
+      }
+
+      return Promise.resolve({ val: 'Parent type' })
+    })
+
+    integramService.getReferenceOptions.mockResolvedValue({
+      501: 'Reference value'
+    })
+  })
+
+  it('renders each base editor according to Integram type ids and array metadata', async () => {
+    const wrapper = mountEditor()
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="html-editor"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="datetime-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="date-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="file-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="checkbox-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="memo-field"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="password-field"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-test="input-number"]')).toHaveLength(2)
+    expect(wrapper.findAll('[data-test="input-text"]').length).toBeGreaterThanOrEqual(2)
+    expect(wrapper.find('[data-test="reference-field"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Перейти к списку')
+  })
+})

--- a/src/components/integram/fields/DateField.vue
+++ b/src/components/integram/fields/DateField.vue
@@ -42,6 +42,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { parseIntegramDateValue } from '@/utils/integramDateValues'
 
 const props = defineProps({
   id: String,
@@ -82,7 +83,7 @@ const computedModelValue = computed(() => {
     // Special value - resolve to actual date for calendar display
     return resolveSpecialValue(props.modelValue)
   }
-  return props.modelValue
+  return parseIntegramDateValue(props.modelValue)
 })
 
 function toggleSpecialValues(event) {

--- a/src/components/integram/fields/DateTimeField.vue
+++ b/src/components/integram/fields/DateTimeField.vue
@@ -28,6 +28,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { parseIntegramDateValue } from '@/utils/integramDateValues'
 
 const props = defineProps({
   id: String,
@@ -52,7 +53,7 @@ const computedModelValue = computed(() => {
     // Special value - resolve to actual datetime for calendar display
     return new Date()
   }
-  return props.modelValue
+  return parseIntegramDateValue(props.modelValue)
 })
 
 function toggleSpecialValues(event) {

--- a/src/services/__tests__/integramApiClient.spec.js
+++ b/src/services/__tests__/integramApiClient.spec.js
@@ -55,4 +55,42 @@ describe('IntegramApiClient', () => {
     expect(url).toBe('https://app.integram.io/api/my/_m_del/9001')
     expect(body.get('_xsrf')).toBe('xsrf-token')
   })
+
+  it('posts form-style requisite keys through _m_set without double-prefixing', async () => {
+    axios.post.mockResolvedValue({ data: { ok: true } })
+
+    await client.setObjectRequisites(285, {
+      t100: 'updated text',
+      b101: '1',
+      102: true
+    })
+
+    const [url, body] = axios.post.mock.calls[0]
+
+    expect(url).toBe('https://app.integram.io/api/my/_m_set/285')
+    expect(body.get('t100')).toBe('updated text')
+    expect(body.get('b101')).toBe('1')
+    expect(body.get('t102')).toBe('X')
+    expect(body.get('b102')).toBe('1')
+    expect(body.get('tt100')).toBeNull()
+  })
+
+  it('creates objects with normalized form-style requisite keys and parent id', async () => {
+    axios.post.mockResolvedValue({ data: { id: 901 } })
+
+    await client.createObject(77, 'Copy source', {
+      t100: 'text value',
+      101: false
+    }, 285)
+
+    const [url, body] = axios.post.mock.calls[0]
+
+    expect(url).toBe('https://app.integram.io/api/my/_m_new/77')
+    expect(body.get('t77')).toBe('Copy source')
+    expect(body.get('up')).toBe('285')
+    expect(body.get('t100')).toBe('text value')
+    expect(body.get('t101')).toBe('')
+    expect(body.get('b101')).toBe('1')
+    expect(body.get('tt100')).toBeNull()
+  })
 })

--- a/src/services/integramApiClient.js
+++ b/src/services/integramApiClient.js
@@ -14,6 +14,14 @@ import axios from 'axios'
 export function formatRequisiteValue(value) {
   if (value === null || value === undefined || value === '') return value
 
+  if (typeof value === 'boolean') {
+    return value ? 'X' : ''
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(',')
+  }
+
   const isDateObject = value instanceof Date ||
     (value && typeof value.getFullYear === 'function' && typeof value.getMonth === 'function')
 
@@ -44,6 +52,29 @@ export function formatRequisiteValue(value) {
   }
 
   return value
+}
+
+function normalizeRequisiteKey(reqId) {
+  const key = String(reqId)
+  return /^(t|b)\d+$/.test(key) ? key : `t${key}`
+}
+
+export function buildRequisitePayload(requisites = {}) {
+  if (!requisites || typeof requisites !== 'object') return {}
+
+  const data = {}
+
+  for (const [reqId, reqValue] of Object.entries(requisites)) {
+    const key = normalizeRequisiteKey(reqId)
+    const formatted = formatRequisiteValue(reqValue)
+    data[key] = formatted !== null && formatted !== undefined ? formatted : ''
+
+    if (typeof reqValue === 'boolean' && /^t\d+$/.test(key)) {
+      data[`b${key.slice(1)}`] = '1'
+    }
+  }
+
+  return data
 }
 
 export class IntegramApiClient {
@@ -627,27 +658,18 @@ export class IntegramApiClient {
   async createObject(typeId, value, requisites = {}, parentId = null) {
     const data = { [`t${typeId}`]: value }
     data.up = parentId || 1
-    for (const [reqId, reqValue] of Object.entries(requisites)) {
-      data[`t${reqId}`] = formatRequisiteValue(reqValue)
-    }
+    Object.assign(data, buildRequisitePayload(requisites))
     return this.post(`_m_new/${typeId}`, data)
   }
 
   async saveObject(objectId, typeId, value, requisites = {}) {
     const data = { [`t${typeId}`]: value }
-    for (const [reqId, reqValue] of Object.entries(requisites)) {
-      const formatted = formatRequisiteValue(reqValue)
-      data[`t${reqId}`] = formatted !== null && formatted !== undefined ? formatted : ''
-    }
+    Object.assign(data, buildRequisitePayload(requisites))
     return this.post(`_m_save/${objectId}`, data)
   }
 
   async setObjectRequisites(objectId, requisites = {}) {
-    const data = {}
-    for (const [reqId, reqValue] of Object.entries(requisites)) {
-      const formatted = formatRequisiteValue(reqValue)
-      data[`t${reqId}`] = formatted !== null && formatted !== undefined ? formatted : ''
-    }
+    const data = buildRequisitePayload(requisites)
     return this.post(`_m_set/${objectId}`, data)
   }
 

--- a/src/services/integramService.js
+++ b/src/services/integramService.js
@@ -81,7 +81,7 @@ class IntegramService {
   }
 
   async saveObject(objectId, formData) {
-    return integramApiClient.saveObject(objectId, formData);
+    return integramApiClient.setObjectRequisites(objectId, formData);
   }
 }
 

--- a/src/utils/__tests__/integramDateValues.spec.js
+++ b/src/utils/__tests__/integramDateValues.spec.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { parseIntegramDateValue } from '../integramDateValues'
+
+describe('parseIntegramDateValue', () => {
+  it('parses legacy ISO-like date and datetime strings for Calendar components', () => {
+    const date = parseIntegramDateValue('2026-05-09')
+    const dateTime = parseIntegramDateValue('2026-05-09 12:30:15')
+
+    expect(date).toBeInstanceOf(Date)
+    expect(date.getFullYear()).toBe(2026)
+    expect(date.getMonth()).toBe(4)
+    expect(date.getDate()).toBe(9)
+    expect(date.getHours()).toBe(0)
+
+    expect(dateTime).toBeInstanceOf(Date)
+    expect(dateTime.getHours()).toBe(12)
+    expect(dateTime.getMinutes()).toBe(30)
+    expect(dateTime.getSeconds()).toBe(15)
+  })
+
+  it('parses Russian date strings and preserves special/unparseable values', () => {
+    const ruDate = parseIntegramDateValue('09.05.2026 07:08')
+
+    expect(ruDate).toBeInstanceOf(Date)
+    expect(ruDate.getFullYear()).toBe(2026)
+    expect(ruDate.getMonth()).toBe(4)
+    expect(ruDate.getDate()).toBe(9)
+    expect(ruDate.getHours()).toBe(7)
+    expect(ruDate.getMinutes()).toBe(8)
+
+    expect(parseIntegramDateValue('[TODAY]')).toBe('[TODAY]')
+    expect(parseIntegramDateValue('2026-99-99')).toBe('2026-99-99')
+    expect(parseIntegramDateValue('not a date')).toBe('not a date')
+  })
+})

--- a/src/utils/__tests__/integramFieldTypes.spec.js
+++ b/src/utils/__tests__/integramFieldTypes.spec.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getIntegramArrayTypeId,
+  getIntegramBaseType,
+  isIntegramArrayRequisite,
+  isIntegramReferenceRequisite
+} from '../integramFieldTypes'
+
+describe('integramFieldTypes', () => {
+  it('maps legacy base type ids used by object editors', () => {
+    expect(getIntegramBaseType(2)).toBe('HTML')
+    expect(getIntegramBaseType(3)).toBe('SHORT')
+    expect(getIntegramBaseType(4)).toBe('DATETIME')
+    expect(getIntegramBaseType(6)).toBe('PWD')
+    expect(getIntegramBaseType(7)).toBe('BUTTON')
+    expect(getIntegramBaseType(8)).toBe('CHARS')
+    expect(getIntegramBaseType(9)).toBe('DATE')
+    expect(getIntegramBaseType(10)).toBe('FILE')
+    expect(getIntegramBaseType(11)).toBe('BOOLEAN')
+    expect(getIntegramBaseType(12)).toBe('MEMO')
+    expect(getIntegramBaseType(13)).toBe('NUMBER')
+    expect(getIntegramBaseType(14)).toBe('SIGNED')
+    expect(getIntegramBaseType(15)).toBe('CALCULATABLE')
+    expect(getIntegramBaseType(16)).toBe('REPORT_COLUMN')
+    expect(getIntegramBaseType(17)).toBe('PATH')
+  })
+
+  it('does not classify DATETIME type id 4 as an array by itself', () => {
+    expect(isIntegramArrayRequisite({ id: 4, type: '4' })).toBe(false)
+  })
+
+  it('detects subordinate array requisites from explicit array metadata', () => {
+    const req = { id: 90, type: '3', arr: 901 }
+
+    expect(isIntegramArrayRequisite(req)).toBe(true)
+    expect(getIntegramArrayTypeId(req)).toBe(901)
+    expect(isIntegramReferenceRequisite(req)).toBe(false)
+  })
+
+  it('detects subordinate array requisites from edit_obj arr_type mapping', () => {
+    const req = { id: 90, type: '3' }
+
+    expect(isIntegramArrayRequisite(req, { 90: 901 })).toBe(true)
+    expect(getIntegramArrayTypeId(req, { 90: 901 })).toBe(901)
+  })
+
+  it('detects references only when the requisite is not an array', () => {
+    expect(isIntegramReferenceRequisite({ id: 18, type: '3', ref: 500 })).toBe(true)
+    expect(isIntegramReferenceRequisite({ id: 90, type: '3', ref: 500, arr: 901 })).toBe(false)
+  })
+})

--- a/src/utils/integramDateValues.js
+++ b/src/utils/integramDateValues.js
@@ -1,0 +1,46 @@
+export function parseIntegramDateValue(value) {
+  if (!value) return value
+  if (value instanceof Date) return value
+  if (typeof value !== 'string') return value
+  if (value.startsWith('[')) return value
+
+  const trimmed = value.trim()
+
+  const isoMatch = trimmed.match(/^(\d{4})[-/.](\d{2})[-/.](\d{2})(?:[T\s]+(\d{2}):(\d{2})(?::(\d{2}))?)?$/)
+  if (isoMatch) {
+    const [, year, month, day, hours = '00', minutes = '00', seconds = '00'] = isoMatch
+    return buildValidDate(year, month, day, hours, minutes, seconds, value)
+  }
+
+  const ruMatch = trimmed.match(/^(\d{2})\.(\d{2})\.(\d{4})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/)
+  if (ruMatch) {
+    const [, day, month, year, hours = '00', minutes = '00', seconds = '00'] = ruMatch
+    return buildValidDate(year, month, day, hours, minutes, seconds, value)
+  }
+
+  return value
+}
+
+function buildValidDate(year, month, day, hours, minutes, seconds, fallback) {
+  const date = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hours),
+    Number(minutes),
+    Number(seconds)
+  )
+
+  if (
+    date.getFullYear() !== Number(year) ||
+    date.getMonth() !== Number(month) - 1 ||
+    date.getDate() !== Number(day) ||
+    date.getHours() !== Number(hours) ||
+    date.getMinutes() !== Number(minutes) ||
+    date.getSeconds() !== Number(seconds)
+  ) {
+    return fallback
+  }
+
+  return date
+}

--- a/src/utils/integramFieldTypes.js
+++ b/src/utils/integramFieldTypes.js
@@ -1,0 +1,57 @@
+export const INTEGRAM_BASE_TYPE_BY_ID = Object.freeze({
+  '0': 'TAB',
+  '1': 'SHORT',
+  '2': 'HTML',
+  '3': 'SHORT',
+  '4': 'DATETIME',
+  '5': 'GRANT',
+  '6': 'PWD',
+  '7': 'BUTTON',
+  '8': 'CHARS',
+  '9': 'DATE',
+  '10': 'FILE',
+  '11': 'BOOLEAN',
+  '12': 'MEMO',
+  '13': 'NUMBER',
+  '14': 'SIGNED',
+  '15': 'CALCULATABLE',
+  '16': 'REPORT_COLUMN',
+  '17': 'PATH',
+  '18': 'USER',
+  '19': 'CONNECT',
+  '20': 'TIME'
+})
+
+function hasValue(value) {
+  return value !== undefined && value !== null && value !== ''
+}
+
+function getMappedArrayTypeId(req, arrTypeMapping = {}) {
+  if (!req) return null
+  return arrTypeMapping[req.id] ?? arrTypeMapping[String(req.id)] ?? null
+}
+
+export function getIntegramBaseType(typeCode) {
+  return INTEGRAM_BASE_TYPE_BY_ID[String(typeCode)] || 'SHORT'
+}
+
+export function getIntegramArrayTypeId(req, arrTypeMapping = {}) {
+  if (!req) return null
+
+  const mappedTypeId = getMappedArrayTypeId(req, arrTypeMapping)
+  if (hasValue(mappedTypeId)) return mappedTypeId
+
+  if (hasValue(req.arr_type)) return req.arr_type
+  if (hasValue(req.arr)) return req.arr
+  if (hasValue(req.arr_id)) return req.arr_id
+
+  return null
+}
+
+export function isIntegramArrayRequisite(req, arrTypeMapping = {}) {
+  return hasValue(getIntegramArrayTypeId(req, arrTypeMapping))
+}
+
+export function isIntegramReferenceRequisite(req, arrTypeMapping = {}) {
+  return !isIntegramArrayRequisite(req, arrTypeMapping) && hasValue(req?.ref)
+}

--- a/src/views/integram/IntegramObjectEdit.vue
+++ b/src/views/integram/IntegramObjectEdit.vue
@@ -342,6 +342,12 @@ import integramService from '@/services/integramService';
 import integramApiClient from '@/services/integramApiClient';
 import IntegramEnhancedObjectEditor from '@/components/integram/IntegramEnhancedObjectEditor.vue';
 import IntegramBreadcrumb from '@/components/integram/IntegramBreadcrumb.vue';
+import {
+  getIntegramArrayTypeId,
+  getIntegramBaseType,
+  isIntegramArrayRequisite,
+  isIntegramReferenceRequisite
+} from '@/utils/integramFieldTypes';
 
 const route = useRoute();
 const router = useRouter();
@@ -714,16 +720,16 @@ async function loadData() {
           const metadata = {};
 
           metaData.reqs.forEach(req => {
-            const isArray = req.type === '4'; // Array type
-            const isReference = !isArray && (req.ref !== undefined);
+            const isArray = isIntegramArrayRequisite(req, result.arr_type || {});
+            const isReference = isIntegramReferenceRequisite(req, result.arr_type || {});
             const isMulti = req.attrs && req.attrs.includes(':MULTI:');
 
             metadata[req.id] = {
               isReference,
               isArray,
               isMulti,
-              refTypeId: req.ref || null,
-              baseType: req.type || null
+              refTypeId: isArray ? getIntegramArrayTypeId(req, result.arr_type || {}) : (req.ref || null),
+              baseType: getIntegramBaseType(req.type)
             };
           });
 


### PR DESCRIPTION
## Summary

Fixes #18.

This PR fixes the active Vue `/edit_obj/:objectId` flow so base field types, legacy DML payloads, and date field rendering match Integram contracts more closely.

## Changes

- Added a shared Integram field-type helper for legacy type ids and subordinate array metadata.
- Fixed `IntegramEnhancedObjectEditor` so `DATETIME` type id `4` renders as a datetime editor instead of a subordinate table link.
- Restored correct handling for HTML, password, numeric, boolean, memo, file, reference, and subordinate array fields in the editor metadata pass.
- Normalized `_m_set`, `_m_save`, and `_m_new` requisite payloads so both bare ids (`100`) and legacy form keys (`t100`, `b100`) are posted without double-prefixing.
- Normalized boolean fields to the legacy checkbox format (`X`/empty plus `b{id}=1`).
- Normalized legacy date/datetime strings before passing them to PrimeVue Calendar fields, preventing runtime crashes on values like `2026-05-09 12:30:00`.
- Fixed duplicate-object argument order and navigation back to `/edit_obj/{id}`.
- Removed the generated placeholder `.gitkeep` from the PR branch.

## Reproduction and Tests

Regression coverage added:

- Component test with mocked `edit_obj` and metadata responses verifies the editor renders core base field editors and subordinate-array links from fixtures.
- API client tests verify `_m_set` and `_m_new` payloads preserve form-style keys and boolean values.
- Unit tests verify the legacy type-id mapping, array/reference detection, and date/datetime string parsing.
- Playwright MCP smoke check loaded `/demo/edit_obj/123` with mocked Integram responses and verified the editor title, core field labels, subordinate-list link, and no console errors.

## Verification

- `npm test` - passed, 5 files, 25 tests.
- `npm run build` - passed. Vite still reports the existing large chunk-size warning.
- Browser smoke - passed against local Vite server with mocked API calls: `/demo/object/123`, `/demo/xsrf`, `/demo/edit_obj/123`, `/demo/metadata/77`, `/demo/metadata/1`, `/demo/_ref_reqs/18`.

## Notes

No screenshots are included because this change is API payload and editor metadata/rendering behavior covered by mocked component/unit tests plus the browser smoke, not a visual redesign.
