### PR TITLE
Сохранить пользовательские настройки Интеграма

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T16:25:48.196Z for PR creation at branch issue-35-a9c9faf5a69c for issue https://github.com/ideav/vue-gram/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T16:25:48.196Z for PR creation at branch issue-35-a9c9faf5a69c for issue https://github.com/ideav/vue-gram/issues/35

--- a/docs/INTEGRAM_STORAGE_COMPATIBILITY.md
+++ b/docs/INTEGRAM_STORAGE_COMPATIBILITY.md
@@ -1,0 +1,26 @@
+# Integram Storage Compatibility
+
+Issue #35 tracks compatibility between the legacy Integram frontend and the Vue rewrite for user settings stored in cookies, `localStorage`, and Settings objects. Vue must read legacy data first where it exists, keep writing backend-compatible values, and avoid deleting legacy fallback keys during the migration window.
+
+## Storage Key Matrix
+
+| Area | Legacy source | Legacy key or object | Vue key or object | Read behavior | Write behavior |
+| --- | --- | --- | --- | --- | --- |
+| Theme | Legacy shell / earlier Vue bridge | `localStorage.theme` with `dark` or `light` | `localStorage.darkTheme` with `true` or `false` | `useTheme` prefers `theme`, then falls back to `darkTheme`. | Vue writes both keys so old and new callers stay in sync. |
+| Page font size | Legacy shell cookie | `integram-table-font-settings` JSON with `pageFontSize` | Same cookie | `useIntegramShellSettings` reads the cookie and applies the matching root font size. | Vue writes the same cookie shape. |
+| Brand background | Legacy shell cookie | `brand-bg-{database}` | Same cookie | Vue reads the database-specific cookie and applies `--brand-bg-opacity`. | Vue writes the same database-specific cookie. |
+| Sidebar collapsed | Vue shell setting | `appSidebarCollapsed_{database}` | Same key | Vue reads the database-specific key. | Vue writes the same key. |
+| Sidebar width | Vue shell setting | `sidebarWidth_{database}` cookie | Same cookie | Vue reads the database-specific cookie. | Vue writes the same cookie. |
+| Menu expansion | Vue shell setting | none in the legacy top-nav UI | `menuExpanded_{database}` | Vue reads the database-specific JSON array of expanded menu ids. | Vue writes normalized string ids to the same key. |
+| Table workspace folders | Legacy `templates/dict.html` Settings fallback | `localStorage.settingsID` containing folder JSON when Settings object persistence failed | `integram-table-folders-config`; Settings object type `269`, `t271=UI`, `t273=<folder JSON>` | Vue loads `integram-table-folders-config` or falls back to `settingsID`; a server Settings object still overrides local fallback data when it is available. | Vue writes `integram-table-folders-config` and the Settings object. It does not overwrite `settingsID`. |
+| Table workspace Settings object id | Vue migration helper | none reliable; legacy `settingsID` is config JSON, not an object id | `integram-table-folders-settings-id` | Vue reads only the Vue id key. | Vue writes the object id returned by `_m_save` or `_m_new/269`. |
+| Data table behavior | Legacy object table cookies / Vue setting | `default_limit` cookie for rows per page | `datatable_settings` for background load and date display options | Vue reads `default_limit` for the initial `LIMIT` and reads `datatable_settings` with defaults for missing options. | Vue writes `datatable_settings`; row-limit writes use the legacy `default_limit` cookie helper. |
+| Table filters and sort | Legacy object table URL state | `F_*`, `FR_*`, `TO_*`, `F_U`, `F_I`, `lnx`, `order_val`, `desc` query params | Same URL params | Vue passes legacy query params through to object-list and count requests. | Vue keeps query-state compatible with existing backend contracts. |
+| Dashboard panel settings | Legacy dashboard panel object | requisite `1165` (`t1165`) containing JSON settings; report alias `panelSettings` may expose the same value | Same object requisite `1165` | Vue reads `panelSettings` first, then legacy `t1165` / `reqs[1165]` / `requisites[1165]`. | Vue serializes settings as JSON and writes requisite `1165` through `_m_set`. |
+
+## Migration Rules
+
+- Read compatibility is additive: new Vue keys do not remove the ability to read legacy keys.
+- Renamed local keys are explicit. `settingsID` is treated only as legacy table folder JSON because the legacy template used it as a config fallback, not a stable Settings object id.
+- Object-backed settings keep the legacy backend contract. Table folders remain `type 269 / t271=UI / t273=<JSON>`, and dashboard panels remain `t1165=<JSON>`.
+- Invalid JSON falls back to current defaults instead of clearing the old value.

--- a/e2e/integram-shell.spec.ts
+++ b/e2e/integram-shell.spec.ts
@@ -60,11 +60,17 @@ async function mockIntegramApi(page: Page) {
 
 async function seedLegacyShellState(page: Page) {
   await page.addInitScript((seededSession) => {
+    const hasCookie = (name: string) => document.cookie
+      .split(';')
+      .some(cookie => cookie.trim().startsWith(`${name}=`))
+
     localStorage.setItem('token', 'auth-token')
-    localStorage.setItem('theme', 'dark')
+    if (!localStorage.getItem('theme')) localStorage.setItem('theme', 'dark')
     localStorage.setItem('integram_session', JSON.stringify(seededSession))
-    document.cookie = `integram-table-font-settings=${encodeURIComponent(JSON.stringify({ pageFontSize: 'larger' }))}; path=/`
-    document.cookie = 'brand-bg-my=0.4; path=/'
+    if (!hasCookie('integram-table-font-settings')) {
+      document.cookie = `integram-table-font-settings=${encodeURIComponent(JSON.stringify({ pageFontSize: 'larger' }))}; path=/`
+    }
+    if (!hasCookie('brand-bg-my')) document.cookie = 'brand-bg-my=0.4; path=/'
   }, session)
 }
 
@@ -99,6 +105,12 @@ test.describe('Integram Vue shell parity', () => {
     }
 
     await page.getByTitle('Шрифт меньше').click()
+    await expect.poll(() => page.evaluate(() => document.documentElement.style.fontSize)).toBe('0.7rem')
+
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+    await expect(page.locator('body')).toHaveClass(/brand-bg-on/)
+    await expect(page.locator('#cookie-consent')).toHaveCount(0)
     await expect.poll(() => page.evaluate(() => document.documentElement.style.fontSize)).toBe('0.7rem')
   })
 

--- a/src/components/integram/IntegramDataTableWrapper.vue
+++ b/src/components/integram/IntegramDataTableWrapper.vue
@@ -1061,6 +1061,11 @@ import integramApiClient from '@/services/integramApiClient'
 import DataTable from '@/components/integram/DataTable.vue'
 import IntegramBreadcrumb from '@/components/integram/IntegramBreadcrumb.vue'
 import ReferenceField from '@/components/integram/fields/ReferenceField.vue'
+import {
+  loadDataTableSettings,
+  loadRowsPerPagePreference,
+  saveDataTableSettings
+} from '@/utils/dataTableSettings'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Textarea from 'primevue/textarea'
@@ -1310,61 +1315,15 @@ const rows = ref([])
 
 // Pagination
 const currentPage = ref(1)
-const rowsPerPage = ref(50)
+const rowsPerPage = ref(loadRowsPerPagePreference())
 const hasMore = ref(false)
 
 // Background loading & Smart loading
-const STORAGE_KEY = 'datatable_settings'
-const DEFAULT_SETTINGS = {
-  autoLoadAll: true,           // Фоновая загрузка всех данных (вкл по умолчанию)
-  autoLoadDirs: true,          // Автозагрузка справочников (вкл по умолчанию)
-  maxAutoLoadSize: 20000,      // Макс размер для автозагрузки
-  backgroundChunkSize: 1000,   // Размер chunk
-  backgroundDelay: 150,        // Задержка между chunk (мс)
-  dateStyle: 'relative'        // Стиль дат: classic, relative, chip, smart
-}
-
-// Load settings from localStorage
-// ВАЖНО: Эта функция СОЗДАЕТ запись в localStorage при первом открытии!
-function loadSettings() {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-
-    if (stored) {
-      // ✅ Пользователь уже открывал таблицу ранее - используем СОХРАНЕННЫЕ настройки
-      const parsedSettings = JSON.parse(stored)
-      console.log('[loadSettings] Загружены сохраненные настройки из localStorage:', parsedSettings)
-      return { ...DEFAULT_SETTINGS, ...parsedSettings }
-    } else {
-      // ✅ ПЕРВОЕ ОТКРЫТИЕ - инициализируем localStorage с дефолтными значениями
-      console.log('[loadSettings] ПЕРВОЕ ОТКРЫТИЕ: инициализируем localStorage с дефолтными настройками')
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_SETTINGS))
-      return DEFAULT_SETTINGS
-    }
-  } catch (e) {
-    console.error('[loadSettings] Ошибка при загрузке настроек:', e)
-    // При ошибке все равно пытаемся сохранить дефолты
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_SETTINGS))
-    } catch {
-      console.error('[loadSettings] Не удалось сохранить дефолтные настройки')
-    }
-    return DEFAULT_SETTINGS
-  }
-}
-
-// Save settings to localStorage
-// ВАЖНО: Вызывается из toggleAutoLoad() и toggleAutoLoadDirs() когда пользователь изменяет настройки
 function saveSettings(newSettings) {
-  try {
-    console.log('[saveSettings] Сохраняем НОВЫЕ настройки в localStorage:', newSettings)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings))
-  } catch (e) {
-    console.error('[saveSettings] Ошибка при сохранении настроек:', e)
-  }
+  saveDataTableSettings(newSettings)
 }
 
-const settings = ref(loadSettings())
+const settings = ref(loadDataTableSettings())
 const allRows = ref([])                    // Все загруженные строки
 const isBackgroundLoading = ref(false)     // Флаг фоновой загрузки
 const backgroundProgress = ref(0)          // Прогресс (0-100)

--- a/src/services/integramService.js
+++ b/src/services/integramService.js
@@ -8,7 +8,8 @@
 import integramApiClient from './integramApiClient';
 import {
   DASHBOARD_PANEL_SETTINGS_REQ_ID,
-  dateToDashboardYmd
+  dateToDashboardYmd,
+  serializeDashboardPanelSettings
 } from '@/utils/dashboard';
 
 class IntegramService {
@@ -109,7 +110,7 @@ class IntegramService {
 
   async saveDashboardPanelSettings(panelId, settings) {
     return integramApiClient.setObjectRequisites(panelId, {
-      [DASHBOARD_PANEL_SETTINGS_REQ_ID]: JSON.stringify(settings || [])
+      [DASHBOARD_PANEL_SETTINGS_REQ_ID]: serializeDashboardPanelSettings(settings)
     });
   }
 

--- a/src/utils/__tests__/dashboard.spec.js
+++ b/src/utils/__tests__/dashboard.spec.js
@@ -3,10 +3,13 @@ import { describe, expect, it } from 'vitest'
 import {
   buildDashboardState,
   collectDashboardVizData,
+  DASHBOARD_PANEL_SETTINGS_REQ_ID,
+  extractDashboardPanelSettings,
   formatDashboardNumber,
   normalizeDashboardReport,
   normalizeNumberText,
-  parseDashboardFormula
+  parseDashboardFormula,
+  serializeDashboardPanelSettings
 } from '../dashboard'
 import {
   dashboardModelFixture,
@@ -93,5 +96,41 @@ describe('dashboard utilities', () => {
     expect(pivot.rows).toEqual(['Won'])
     expect(pivot.columns).toEqual(['Ann', 'Bob'])
     expect(pivot.matrix).toEqual([[1000, 500]])
+  })
+
+  it('reads and writes object-backed legacy panel settings', () => {
+    const settings = [{ type: 'line', default: true }]
+    const row = {
+      panelSettings: '',
+      reqs: {
+        [DASHBOARD_PANEL_SETTINGS_REQ_ID]: { val: JSON.stringify(settings) }
+      }
+    }
+
+    expect(extractDashboardPanelSettings(row)).toEqual(settings)
+    expect(serializeDashboardPanelSettings(settings)).toBe(JSON.stringify(settings))
+  })
+
+  it('builds panel state from object-backed settings when report aliases are absent', () => {
+    const modelRows = [
+      {
+        ...dashboardModelFixture[0],
+        panelSettings: '',
+        reqs: {
+          [DASHBOARD_PANEL_SETTINGS_REQ_ID]: {
+            val: JSON.stringify([{ type: 'line', default: true }])
+          }
+        }
+      }
+    ]
+
+    const state = buildDashboardState({
+      modelRows,
+      periodData: dashboardPeriodFixture,
+      sourceRows: dashboardValuesFixture
+    })
+
+    expect(state.sheets[0].panels[0].settings).toEqual([{ type: 'line', default: true }])
+    expect(state.sheets[0].panels[0].activeViz).toBe('line')
   })
 })

--- a/src/utils/__tests__/dataTableSettings.spec.js
+++ b/src/utils/__tests__/dataTableSettings.spec.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DATA_TABLE_SETTINGS_STORAGE_KEY,
+  DEFAULT_DATA_TABLE_SETTINGS,
+  loadDataTableSettings,
+  loadRowsPerPagePreference,
+  saveDataTableSettings,
+  saveRowsPerPagePreference
+} from '../dataTableSettings'
+
+function clearCookies() {
+  document.cookie.split(';').forEach((cookie) => {
+    const name = cookie.split('=')[0]?.trim()
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`
+    }
+  })
+}
+
+describe('data table settings storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    clearCookies()
+  })
+
+  it('initializes the Vue datatable_settings key without changing legacy cookies', () => {
+    document.cookie = 'default_limit=125; path=/'
+
+    expect(loadDataTableSettings()).toEqual(DEFAULT_DATA_TABLE_SETTINGS)
+    expect(JSON.parse(localStorage.getItem(DATA_TABLE_SETTINGS_STORAGE_KEY))).toEqual(DEFAULT_DATA_TABLE_SETTINGS)
+    expect(loadRowsPerPagePreference()).toBe(125)
+  })
+
+  it('merges saved Vue settings with current defaults', () => {
+    localStorage.setItem(DATA_TABLE_SETTINGS_STORAGE_KEY, JSON.stringify({
+      autoLoadAll: false,
+      dateStyle: 'classic'
+    }))
+
+    expect(loadDataTableSettings()).toEqual({
+      ...DEFAULT_DATA_TABLE_SETTINGS,
+      autoLoadAll: false,
+      dateStyle: 'classic'
+    })
+  })
+
+  it('writes Vue settings and the legacy default_limit cookie explicitly', () => {
+    saveDataTableSettings({ ...DEFAULT_DATA_TABLE_SETTINGS, autoLoadDirs: false })
+    saveRowsPerPagePreference(75)
+
+    expect(JSON.parse(localStorage.getItem(DATA_TABLE_SETTINGS_STORAGE_KEY))).toMatchObject({
+      autoLoadDirs: false
+    })
+    expect(document.cookie).toContain('default_limit=75')
+    expect(loadRowsPerPagePreference()).toBe(75)
+  })
+})

--- a/src/utils/__tests__/integramMenu.spec.js
+++ b/src/utils/__tests__/integramMenu.spec.js
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   buildLegacyMenuPath,
   filterMenuTree,
   findActiveMenuItem,
   flattenMenuTree,
+  getExpandedMenuStorageKey,
+  loadExpandedMenuIds,
+  saveExpandedMenuIds,
   normalizeMenuData
 } from '../integramMenu'
 
@@ -18,6 +21,10 @@ const legacyMenuData = [
 ]
 
 describe('integram menu adapter', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('normalizes legacy server menuData into a stable tree', () => {
     const tree = normalizeMenuData(legacyMenuData)
 
@@ -75,5 +82,13 @@ describe('integram menu adapter', () => {
 
     expect(rows.map(row => row.item.label)).toEqual(['Рабочие места', 'Запросы'])
     expect(rows[1].isSearchMatch).toBe(true)
+  })
+
+  it('persists expanded menu ids with the Vue menuExpanded database key', () => {
+    saveExpandedMenuIds('my', new Set(['root', 42]))
+
+    expect(getExpandedMenuStorageKey('my')).toBe('menuExpanded_my')
+    expect(JSON.parse(localStorage.getItem('menuExpanded_my'))).toEqual(['root', '42'])
+    expect(loadExpandedMenuIds('my')).toEqual(new Set(['root', '42']))
   })
 })

--- a/src/utils/__tests__/tableWorkspace.spec.js
+++ b/src/utils/__tests__/tableWorkspace.spec.js
@@ -1,15 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   DEFAULT_TABLE_FOLDERS,
   detectTableBaseType,
   extractTableSettings,
   hasStructureWriteGrant,
+  loadTableFolderConfigFromStorage,
   normalizeFolderConfig,
   normalizeTableList,
+  saveTableFolderConfigToStorage,
   tableMatchesQuery,
 } from '../tableWorkspace'
 
 describe('tableWorkspace helpers', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('normalizes terms payloads from the legacy tables endpoint', () => {
     expect(
       normalizeTableList([
@@ -113,6 +119,29 @@ describe('tableWorkspace helpers', () => {
         Служебные: { open: false, tabs: ['269'] },
       },
     })
+  })
+
+  it('migrates the legacy settingsID localStorage fallback without mutating it', () => {
+    const legacyConfig = {
+      Избранное: { open: true, tabs: [18] },
+      Служебные: { open: false, tabs: ['269'] },
+    }
+    localStorage.setItem('settingsID', JSON.stringify(legacyConfig))
+
+    expect(loadTableFolderConfigFromStorage()).toEqual({
+      Избранное: { open: true, tabs: ['18'] },
+      Служебные: { open: false, tabs: ['269'] },
+    })
+
+    const nextConfig = {
+      Избранное: { open: false, tabs: ['42'] },
+    }
+    saveTableFolderConfigToStorage(nextConfig)
+
+    expect(JSON.parse(localStorage.getItem('integram-table-folders-config'))).toEqual({
+      Избранное: { open: false, tabs: ['42'] },
+    })
+    expect(localStorage.getItem('settingsID')).toBe(JSON.stringify(legacyConfig))
   })
 
   it('matches the legacy structure WRITE grant and hides controls otherwise', () => {

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -306,6 +306,39 @@ export function normalizeDashboardSettings(settings) {
   return parsePanelSettings(settings)
 }
 
+function unwrapSettingsValue(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+  return value.val ?? value.value ?? value.UI ?? value.settings ?? value.panelSettings ?? null
+}
+
+export function extractDashboardPanelSettings(row = {}) {
+  const candidates = [
+    row.panelSettings,
+    row.panel_settings,
+    row.dashboardPanelSettings,
+    row[`t${DASHBOARD_PANEL_SETTINGS_REQ_ID}`],
+    row[DASHBOARD_PANEL_SETTINGS_REQ_ID],
+    row[String(DASHBOARD_PANEL_SETTINGS_REQ_ID)],
+    row.reqs?.[DASHBOARD_PANEL_SETTINGS_REQ_ID],
+    row.reqs?.[String(DASHBOARD_PANEL_SETTINGS_REQ_ID)],
+    row.reqs?.[`t${DASHBOARD_PANEL_SETTINGS_REQ_ID}`],
+    row.requisites?.[DASHBOARD_PANEL_SETTINGS_REQ_ID],
+    row.requisites?.[String(DASHBOARD_PANEL_SETTINGS_REQ_ID)],
+    row.requisites?.[`t${DASHBOARD_PANEL_SETTINGS_REQ_ID}`]
+  ]
+
+  for (const candidate of candidates) {
+    const value = unwrapSettingsValue(candidate)
+    if (hasValue(value)) return parsePanelSettings(value)
+  }
+
+  return []
+}
+
+export function serializeDashboardPanelSettings(settings = []) {
+  return JSON.stringify(parsePanelSettings(settings))
+}
+
 function splitList(value) {
   return asString(value)
     .split(',')
@@ -536,7 +569,7 @@ function ensurePanel(state, sheet, row, reports) {
   const id = `fp${panelId}`
   if (state.panelById.has(id)) return state.panelById.get(id)
 
-  const settings = parsePanelSettings(row.panelSettings)
+  const settings = extractDashboardPanelSettings(row)
   const reportId = resolveDashboardPanelReportId(row)
   const report = reportId && reports[reportId] ? reports[reportId] : null
   const panel = {

--- a/src/utils/dataTableSettings.js
+++ b/src/utils/dataTableSettings.js
@@ -1,0 +1,102 @@
+export const DATA_TABLE_SETTINGS_STORAGE_KEY = 'datatable_settings'
+export const LEGACY_ROWS_PER_PAGE_COOKIE = 'default_limit'
+
+export const DEFAULT_DATA_TABLE_SETTINGS = Object.freeze({
+  autoLoadAll: true,
+  autoLoadDirs: true,
+  maxAutoLoadSize: 20000,
+  backgroundChunkSize: 1000,
+  backgroundDelay: 150,
+  dateStyle: 'relative'
+})
+
+function canUseLocalStorage() {
+  return typeof localStorage !== 'undefined'
+}
+
+function canUseDocument() {
+  return typeof document !== 'undefined'
+}
+
+function cloneDefaultSettings() {
+  return { ...DEFAULT_DATA_TABLE_SETTINGS }
+}
+
+function normalizeSettings(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return cloneDefaultSettings()
+  }
+
+  return {
+    ...DEFAULT_DATA_TABLE_SETTINGS,
+    ...value
+  }
+}
+
+function getCookie(name) {
+  if (!canUseDocument()) return null
+
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = document.cookie.match(new RegExp(`(?:^|; )${escaped}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+function setCookie(name, value, maxAge = 31622400) {
+  if (!canUseDocument()) return
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}`
+}
+
+export function loadDataTableSettings() {
+  if (!canUseLocalStorage()) return cloneDefaultSettings()
+
+  try {
+    const stored = localStorage.getItem(DATA_TABLE_SETTINGS_STORAGE_KEY)
+    if (stored) {
+      return normalizeSettings(JSON.parse(stored))
+    }
+
+    const defaults = cloneDefaultSettings()
+    localStorage.setItem(DATA_TABLE_SETTINGS_STORAGE_KEY, JSON.stringify(defaults))
+    return defaults
+  } catch (error) {
+    console.error('[dataTableSettings] Failed to load settings:', error)
+    const defaults = cloneDefaultSettings()
+    try {
+      localStorage.setItem(DATA_TABLE_SETTINGS_STORAGE_KEY, JSON.stringify(defaults))
+    } catch {
+      // Ignore storage failures after reporting the original read/parse error.
+    }
+    return defaults
+  }
+}
+
+export function saveDataTableSettings(settings) {
+  if (!canUseLocalStorage()) return false
+
+  try {
+    localStorage.setItem(DATA_TABLE_SETTINGS_STORAGE_KEY, JSON.stringify(normalizeSettings(settings)))
+    return true
+  } catch (error) {
+    console.error('[dataTableSettings] Failed to save settings:', error)
+    return false
+  }
+}
+
+export function normalizeRowsPerPagePreference(value, fallback = 50) {
+  const normalizedFallback = Number.parseInt(fallback, 10)
+  const safeFallback = Number.isFinite(normalizedFallback) ? normalizedFallback : 50
+  const parsed = Number.parseInt(value, 10)
+
+  if (!Number.isFinite(parsed)) return safeFallback
+  return Math.min(1000, Math.max(5, parsed))
+}
+
+export function loadRowsPerPagePreference(fallback = 50) {
+  return normalizeRowsPerPagePreference(getCookie(LEGACY_ROWS_PER_PAGE_COOKIE), fallback)
+}
+
+export function saveRowsPerPagePreference(value) {
+  const normalizedValue = normalizeRowsPerPagePreference(value)
+  setCookie(LEGACY_ROWS_PER_PAGE_COOKIE, String(normalizedValue))
+  return normalizedValue
+}

--- a/src/utils/integramMenu.js
+++ b/src/utils/integramMenu.js
@@ -234,6 +234,35 @@ export function findActiveMenuItem(tree, fullPath, database) {
   )
 }
 
+function canUseLocalStorage() {
+  return typeof localStorage !== 'undefined'
+}
+
+export function getExpandedMenuStorageKey(database) {
+  return `menuExpanded_${database || 'default'}`
+}
+
+export function loadExpandedMenuIds(database) {
+  if (!canUseLocalStorage()) return new Set()
+
+  try {
+    const raw = localStorage.getItem(getExpandedMenuStorageKey(database))
+    const ids = raw ? JSON.parse(raw) : []
+    return new Set(Array.isArray(ids) ? ids.map(String) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+export function saveExpandedMenuIds(database, ids) {
+  if (!canUseLocalStorage()) return false
+
+  const values = ids instanceof Set ? [...ids] : ids
+  const normalized = Array.isArray(values) ? values.map(String) : []
+  localStorage.setItem(getExpandedMenuStorageKey(database), JSON.stringify(normalized))
+  return true
+}
+
 export function buildLegacyMenuPath(database, href) {
   const rawHref = String(href || '').trim()
   if (!rawHref) return ''

--- a/src/utils/tableWorkspace.js
+++ b/src/utils/tableWorkspace.js
@@ -5,6 +5,10 @@ export const DEFAULT_TABLE_FOLDERS = {
   'Скрытые': { open: false, tabs: ['47', '65', '137', '29', '63'] }
 }
 
+export const TABLE_CONFIG_STORAGE_KEY = 'integram-table-folders-config'
+export const TABLE_SETTINGS_ID_STORAGE_KEY = 'integram-table-folders-settings-id'
+export const LEGACY_TABLE_CONFIG_STORAGE_KEY = 'settingsID'
+
 export const TABLE_BASE_TYPES = [
   { value: '3', label: 'Короткая строка (до 127 символов)' },
   { value: '8', label: 'Строка без ограничения длины' },
@@ -179,6 +183,41 @@ export function extractTableSettings(payload) {
   }
 
   return { settingsId: null, config: null }
+}
+
+function canUseLocalStorage() {
+  return typeof localStorage !== 'undefined'
+}
+
+export function loadTableFolderConfigFromStorage() {
+  if (!canUseLocalStorage()) return null
+
+  const storedConfig = localStorage.getItem(TABLE_CONFIG_STORAGE_KEY)
+  if (storedConfig) return normalizeFolderConfig(storedConfig)
+
+  const legacyConfig = localStorage.getItem(LEGACY_TABLE_CONFIG_STORAGE_KEY)
+  if (legacyConfig) return normalizeFolderConfig(legacyConfig)
+
+  return null
+}
+
+export function saveTableFolderConfigToStorage(config) {
+  if (!canUseLocalStorage()) return false
+
+  const normalizedConfig = cloneFolderConfig(config)
+  localStorage.setItem(TABLE_CONFIG_STORAGE_KEY, JSON.stringify(normalizedConfig))
+  return true
+}
+
+export function loadTableSettingsIdFromStorage() {
+  if (!canUseLocalStorage()) return null
+  return localStorage.getItem(TABLE_SETTINGS_ID_STORAGE_KEY)
+}
+
+export function saveTableSettingsIdToStorage(settingsId) {
+  if (!canUseLocalStorage() || !settingsId) return false
+  localStorage.setItem(TABLE_SETTINGS_ID_STORAGE_KEY, String(settingsId))
+  return true
 }
 
 export function hasStructureWriteGrant(grants) {

--- a/src/views/integram/IntegramDataTableView.vue
+++ b/src/views/integram/IntegramDataTableView.vue
@@ -1062,6 +1062,11 @@ import DataTable from '@/components/integram/DataTable.vue'
 import IntegramBreadcrumb from '@/components/integram/IntegramBreadcrumb.vue'
 import IntegramDataTableWrapper from '@/components/integram/IntegramDataTableWrapper.vue'
 import ReferenceField from '@/components/integram/fields/ReferenceField.vue'
+import {
+  loadDataTableSettings,
+  loadRowsPerPagePreference,
+  saveDataTableSettings
+} from '@/utils/dataTableSettings'
 import InputText from 'primevue/inputtext'
 import InputNumber from 'primevue/inputnumber'
 import Textarea from 'primevue/textarea'
@@ -1312,61 +1317,15 @@ const rows = ref([])
 
 // Pagination
 const currentPage = ref(1)
-const rowsPerPage = ref(50)
+const rowsPerPage = ref(loadRowsPerPagePreference())
 const hasMore = ref(false)
 
 // Background loading & Smart loading
-const STORAGE_KEY = 'datatable_settings'
-const DEFAULT_SETTINGS = {
-  autoLoadAll: true,           // Фоновая загрузка всех данных (вкл по умолчанию)
-  autoLoadDirs: true,          // Автозагрузка справочников (вкл по умолчанию)
-  maxAutoLoadSize: 20000,      // Макс размер для автозагрузки
-  backgroundChunkSize: 1000,   // Размер chunk
-  backgroundDelay: 150,        // Задержка между chunk (мс)
-  dateStyle: 'relative'        // Стиль дат: classic, relative, chip, smart
-}
-
-// Load settings from localStorage
-// ВАЖНО: Эта функция СОЗДАЕТ запись в localStorage при первом открытии!
-function loadSettings() {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-
-    if (stored) {
-      // ✅ Пользователь уже открывал таблицу ранее - используем СОХРАНЕННЫЕ настройки
-      const parsedSettings = JSON.parse(stored)
-      console.log('[loadSettings] Загружены сохраненные настройки из localStorage:', parsedSettings)
-      return { ...DEFAULT_SETTINGS, ...parsedSettings }
-    } else {
-      // ✅ ПЕРВОЕ ОТКРЫТИЕ - инициализируем localStorage с дефолтными значениями
-      console.log('[loadSettings] ПЕРВОЕ ОТКРЫТИЕ: инициализируем localStorage с дефолтными настройками')
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_SETTINGS))
-      return DEFAULT_SETTINGS
-    }
-  } catch (e) {
-    console.error('[loadSettings] Ошибка при загрузке настроек:', e)
-    // При ошибке все равно пытаемся сохранить дефолты
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_SETTINGS))
-    } catch {
-      console.error('[loadSettings] Не удалось сохранить дефолтные настройки')
-    }
-    return DEFAULT_SETTINGS
-  }
-}
-
-// Save settings to localStorage
-// ВАЖНО: Вызывается из toggleAutoLoad() и toggleAutoLoadDirs() когда пользователь изменяет настройки
 function saveSettings(newSettings) {
-  try {
-    console.log('[saveSettings] Сохраняем НОВЫЕ настройки в localStorage:', newSettings)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings))
-  } catch (e) {
-    console.error('[saveSettings] Ошибка при сохранении настроек:', e)
-  }
+  saveDataTableSettings(newSettings)
 }
 
-const settings = ref(loadSettings())
+const settings = ref(loadDataTableSettings())
 const allRows = ref([])                    // Все загруженные строки
 const isBackgroundLoading = ref(false)     // Флаг фоновой загрузки
 const backgroundProgress = ref(0)          // Прогресс (0-100)

--- a/src/views/integram/IntegramMain.vue
+++ b/src/views/integram/IntegramMain.vue
@@ -403,6 +403,8 @@ import {
   flattenMenuTree,
   getMenuItemAncestors,
   isExternalMenuHref,
+  loadExpandedMenuIds,
+  saveExpandedMenuIds,
   normalizeMenuData
 } from '@/utils/integramMenu'
 
@@ -658,22 +660,12 @@ function loadServerMenuData() {
   rawMenuData.value = serverMenu ? [...serverMenu] : []
 }
 
-function expandedMenuStorageKey() {
-  return `menuExpanded_${database.value || 'default'}`
-}
-
 function loadExpandedMenuState() {
-  try {
-    const raw = localStorage.getItem(expandedMenuStorageKey())
-    const ids = raw ? JSON.parse(raw) : []
-    expandedMenuIds.value = new Set(Array.isArray(ids) ? ids.map(String) : [])
-  } catch {
-    expandedMenuIds.value = new Set()
-  }
+  expandedMenuIds.value = loadExpandedMenuIds(database.value)
 }
 
 function saveExpandedMenuState() {
-  localStorage.setItem(expandedMenuStorageKey(), JSON.stringify([...expandedMenuIds.value]))
+  saveExpandedMenuIds(database.value, expandedMenuIds.value)
 }
 
 function expandActiveAncestors() {

--- a/src/views/integram/IntegramTableList.vue
+++ b/src/views/integram/IntegramTableList.vue
@@ -274,8 +274,11 @@ import {
   getAssignedTableIds,
   getTypeIconClass,
   hasStructureWriteGrant,
-  normalizeFolderConfig,
+  loadTableFolderConfigFromStorage,
+  loadTableSettingsIdFromStorage,
   normalizeTableList,
+  saveTableFolderConfigToStorage,
+  saveTableSettingsIdToStorage,
   tableMatchesQuery
 } from '@/utils/tableWorkspace'
 
@@ -285,14 +288,11 @@ const toast = useToast()
 const confirm = useConfirm()
 const { isAuthenticated } = useIntegramSession()
 
-const TABLE_CONFIG_STORAGE_KEY = 'integram-table-folders-config'
-const TABLE_SETTINGS_ID_STORAGE_KEY = 'integram-table-folders-settings-id'
-
 const loading = ref(false)
 const error = ref(null)
 const tables = ref([])
 const folderConfig = ref(cloneFolderConfig())
-const settingsId = ref(localStorage.getItem(TABLE_SETTINGS_ID_STORAGE_KEY))
+const settingsId = ref(loadTableSettingsIdFromStorage())
 const grants = ref({})
 const searchQuery = ref('')
 const searchInput = ref(null)
@@ -377,8 +377,8 @@ async function loadWorkspace() {
 
     tables.value = tablesResult.value
 
-    const localConfig = localStorage.getItem(TABLE_CONFIG_STORAGE_KEY)
-    let nextConfig = localConfig ? normalizeFolderConfig(localConfig) : cloneFolderConfig(DEFAULT_TABLE_FOLDERS)
+    const localConfig = loadTableFolderConfigFromStorage()
+    let nextConfig = localConfig || cloneFolderConfig(DEFAULT_TABLE_FOLDERS)
 
     if (settingsResult.status === 'fulfilled') {
       const extracted = extractTableSettings(settingsResult.value)
@@ -386,13 +386,13 @@ async function loadWorkspace() {
         nextConfig = extracted.config
         if (extracted.settingsId) {
           settingsId.value = extracted.settingsId
-          localStorage.setItem(TABLE_SETTINGS_ID_STORAGE_KEY, extracted.settingsId)
+          saveTableSettingsIdToStorage(extracted.settingsId)
         }
       }
     }
 
     folderConfig.value = nextConfig
-    localStorage.setItem(TABLE_CONFIG_STORAGE_KEY, JSON.stringify(nextConfig))
+    saveTableFolderConfigToStorage(nextConfig)
   } catch (err) {
     console.error('Error loading tables workspace:', err)
     error.value = err.message || 'Не удалось загрузить таблицы'
@@ -650,14 +650,14 @@ function reorderFolders(sourceName, targetName) {
 
 async function saveFolderConfig({ silent = false } = {}) {
   const normalizedConfig = cloneFolderConfig(folderConfig.value)
-  localStorage.setItem(TABLE_CONFIG_STORAGE_KEY, JSON.stringify(normalizedConfig))
+  saveTableFolderConfigToStorage(normalizedConfig)
 
   try {
     const result = await integramApiClient.saveTableUiSettings(settingsId.value, normalizedConfig)
     const nextSettingsId = result.id || result.obj
     if (nextSettingsId) {
       settingsId.value = String(nextSettingsId)
-      localStorage.setItem(TABLE_SETTINGS_ID_STORAGE_KEY, String(nextSettingsId))
+      saveTableSettingsIdToStorage(nextSettingsId)
     }
     if (!silent) {
       toast.add({ severity: 'success', summary: 'Сохранено', detail: 'Настройки таблиц обновлены', life: 2000 })


### PR DESCRIPTION
Fixes #35

## Summary
- Added `docs/INTEGRAM_STORAGE_COMPATIBILITY.md` with the legacy/Vue storage key matrix for cookies, `localStorage`, URL state, and Settings object-backed values.
- Centralized storage adapters for data-table settings, table folder settings, expanded menu ids, and dashboard panel settings while preserving legacy read paths and backend contracts.
- Updated the data-table, table workspace, menu shell, and dashboard save paths to use the shared adapters without overwriting legacy fallback keys such as `settingsID`.
- Extended Playwright shell parity coverage so changed shell settings are verified again after a page reload.

## Reproduction / Verification
- Legacy storage can be reproduced by seeding keys such as `settingsID`, `default_limit`, `theme`, `integram-table-font-settings`, `brand-bg-my`, `menuExpanded_my`, and dashboard requisite `1165` / `t1165`.
- New unit tests assert that those legacy values are read compatibly and that Vue writes the expected new keys or object requisites without mutating legacy fallbacks.
- `e2e/integram-shell.spec.ts` now changes the shell font size, reloads the page, and confirms theme, brand background, cookie consent, and font size still persist.

## Tests
- `npm test -- src/utils/__tests__/dataTableSettings.spec.js src/utils/__tests__/tableWorkspace.spec.js src/utils/__tests__/dashboard.spec.js src/utils/__tests__/integramMenu.spec.js` - 4 files, 26 tests passed
- `npm test` - 35 files, 168 tests passed
- `npm run build` - passed; Vite emitted the existing `/i/bg1920.jpg` runtime asset warning and existing chunk-size warnings
- `npm run test:e2e -- e2e/integram-shell.spec.ts` - 2 tests passed
- `npm run test:e2e` - 35 tests passed
